### PR TITLE
nseg parsing bug

### DIFF
--- a/include/boost/url/detail/parse.hpp
+++ b/include/boost/url/detail/parse.hpp
@@ -643,6 +643,7 @@ struct parser
             ec = error::no_match;
             return;
         }
+        ++pt.nseg;
         ++p_;
         if(p_ != end_)
         {
@@ -659,7 +660,6 @@ struct parser
                 p_ + 1, end_, ec);
             if(ec)
                 return;
-            ++pt.nseg;
             while(p_ < end_)
             {
                 if(*p_ != '/')
@@ -860,7 +860,7 @@ parse_url(
     pr.parse_query(pt, ec);
     if(ec)
         return;
-  
+
     pr.parse_fragment(pt, ec);
     if(ec)
         return;
@@ -879,7 +879,7 @@ parse_origin(
     error_code& ec)
 {
     parser pr(s);
-    
+
     // scheme ":" [ "//" authority ]
     if(! pr.match_scheme())
     {

--- a/test/url_view.cpp
+++ b/test/url_view.cpp
@@ -150,7 +150,7 @@ public:
         BOOST_TEST(url_view("//[2001:DB8:1::AB9:C0A8:102]").host_type() == host_type::ipv6);
         BOOST_TEST(url_view("//[684D:1111:222:3333:4444:5555:6:77]").host_type() == host_type::ipv6);
         BOOST_TEST(url_view("//[0:0:0:0:0:0:0:0]").host_type() == host_type::ipv6);
-            
+
         BOOST_TEST(url_view("//[::1:2:3:4:5]").host_type() == host_type::ipv6);
         BOOST_TEST(url_view("//[0:0:0:1:2:3:4:5]").host_type() == host_type::ipv6);
         BOOST_TEST(url_view("//[1:2::3:4:5]").host_type() == host_type::ipv6);
@@ -255,6 +255,17 @@ public:
     void
     testSegments()
     {
+        BOOST_TEST(url_view().segments().size() == 0);
+        BOOST_TEST(url_view("x:a").segments().size() == 1);
+        BOOST_TEST(url_view("x:/a").segments().size() == 1);
+        BOOST_TEST(url_view("x://y/a").segments().size() == 1);
+
+        BOOST_TEST(url_view("x").segments().size() == 1);
+        BOOST_TEST(url_view("x/").segments().size() == 2);
+        BOOST_TEST(url_view("x//").segments().size() == 3);
+
+        BOOST_TEST(url_view("/").segments().size() == 1);
+
         {
             url_view::segments_type const ps{};
             BOOST_TEST(ps.empty());


### PR DESCRIPTION
Added tests for `.segments().size()`. This test was failing:

```
BOOST_TEST(url_view("/").segments().size() == 1);
```

The fix is to move `++pt.nseg` (which was on line 662 in `parse.hpp`) ahead of the `if`. Please review the surrounding code to confirm that this is correct.

(My editor deletes any existing trailing white space, which I assume you don't want in the source).