### PR TITLE
Fix gcc build error:

### DIFF
--- a/include/boost/url/impl/query_params_view.hpp
+++ b/include/boost/url/impl/query_params_view.hpp
@@ -40,6 +40,7 @@ public:
         query_params_view::value_type;
     using pointer = value_type const*;
     using reference = value_type const&;
+    using difference_type = std::ptrdiff_t;
     using iterator_category =
         std::forward_iterator_tag;
 

--- a/include/boost/url/impl/url.ipp
+++ b/include/boost/url/impl/url.ipp
@@ -280,9 +280,9 @@ url::
 ipv4_address() const noexcept
 {
     BOOST_ASSERT(pt_.host_type ==
-        host_type::ipv4);
+        urls::host_type::ipv4);
     if(pt_.host_type !=
-        host_type::ipv4)
+        urls::host_type::ipv4)
         return ipv4_address();
     std::array<
         unsigned char, 4> bytes;
@@ -298,9 +298,9 @@ url::
 ipv6_address() const noexcept
 {
     BOOST_ASSERT(pt_.host_type ==
-        host_type::ipv6);
+        urls::host_type::ipv6);
     if(pt_.host_type !=
-        host_type::ipv6)
+        urls::host_type::ipv6)
         return ipv6_address();
     std::array<
         unsigned char, 16> bytes;
@@ -316,9 +316,9 @@ url::
 ipv_future() const noexcept
 {
     BOOST_ASSERT(pt_.host_type ==
-        host_type::ipvfuture);
+        urls::host_type::ipvfuture);
     if(pt_.host_type !=
-        host_type::ipvfuture)
+        urls::host_type::ipvfuture)
         return {};
     return get(id_host);
 }

--- a/include/boost/url/impl/url_view.ipp
+++ b/include/boost/url/impl/url_view.ipp
@@ -290,9 +290,9 @@ url_view::
 ipv4_address() const noexcept
 {
     BOOST_ASSERT(pt_.host_type ==
-        host_type::ipv4);
+        urls::host_type::ipv4);
     if(pt_.host_type !=
-        host_type::ipv4)
+        urls::host_type::ipv4)
         return ipv4_address();
     std::array<
         unsigned char, 4> bytes;
@@ -308,9 +308,9 @@ url_view::
 ipv6_address() const noexcept
 {
     BOOST_ASSERT(pt_.host_type ==
-        host_type::ipv6);
+        urls::host_type::ipv6);
     if(pt_.host_type !=
-        host_type::ipv6)
+        urls::host_type::ipv6)
         return ipv6_address();
     std::array<
         unsigned char, 16> bytes;
@@ -326,9 +326,9 @@ url_view::
 ipv_future() const noexcept
 {
     BOOST_ASSERT(pt_.host_type ==
-        host_type::ipvfuture);
+        urls::host_type::ipvfuture);
     if(pt_.host_type !=
-        host_type::ipvfuture)
+        urls::host_type::ipvfuture)
         return {};
     return get(id_host);
 }

--- a/include/boost/url/rfc/host_bnf.hpp
+++ b/include/boost/url/rfc/host_bnf.hpp
@@ -39,7 +39,7 @@ class host_bnf
     ipv6_address ipv6_;
     string_view ipvfuture_;
     urls::host_type host_type_ =
-        host_type::none;
+        urls::host_type::none;
 
 public:
     BOOST_URL_DECL

--- a/include/boost/url/rfc/impl/host_bnf.ipp
+++ b/include/boost/url/rfc/impl/host_bnf.ipp
@@ -45,14 +45,14 @@ parse(
         {
             // IPv6address
             t.ipv6_ = v.ipv6;
-            t.host_type_ = host_type::ipv6;
+            t.host_type_ = urls::host_type::ipv6;
             goto finish;
         }
         // VFALCO TODO
         // IPvFuture
         t.ipvfuture_ = v.fut_str;
         t.host_type_ =
-            host_type::ipvfuture;
+            urls::host_type::ipvfuture;
         goto finish;
     }
     // IPv4address
@@ -62,7 +62,7 @@ parse(
         if(parse(it, end, ec, v))
         {
             t.ipv4_ = v.addr;
-            t.host_type_ = host_type::ipv4;
+            t.host_type_ = urls::host_type::ipv4;
             goto finish;
         }
         it = it0;
@@ -81,7 +81,7 @@ parse(
             return false;
         }
         t.host_type_ =
-            host_type::name;
+            urls::host_type::name;
     }
 finish:
     t.str_ = string_view(


### PR DESCRIPTION
Missing defintiion of `difference_type` in query_params_view::iterator