### PR TITLE
Improve parse javadocs

### DIFF
--- a/doc/qbk/0.main.qbk
+++ b/doc/qbk/0.main.qbk
@@ -46,6 +46,7 @@
 [def __Swappable__              [@https://en.cppreference.com/w/cpp/named_req/Swappable ['Swappable]]]
 [def __CharSet__                [link url.charset ['CharSet]]]
 
+[def __std_swap__               [@https://en.cppreference.com/w/cpp/algorithm/swap `std::swap`]]
 [def __authority_view__         [link url.ref.boost__urls__authority_view `authority_view`]]
 [def __error_code__             [link url.ref.boost__urls__error_code `error_code`]]
 [def __parse_uri__              [link url.ref.boost__urls__parse_uri `parse_uri`]]
@@ -56,6 +57,7 @@
 [def __string_view__            [link url.ref.boost__urls__string_view `string_view`]]
 [def __url__                    [link url.ref.boost__urls__url `url`]]
 [def __url_view__               [link url.ref.boost__urls__url_view `url_view`]]
+[def __grammar__parse__         [link url.ref.boost__urls__grammar__parse `parse_uri`]]
 
 [/ Dingbats ]
 
@@ -81,6 +83,7 @@
 [endsect]
 
 [include CharSet.qbk]
+[include 4.0.grammars.qbk]
 
 [section:ref Reference]
 [xinclude quickref.xml]

--- a/doc/qbk/0.main.qbk
+++ b/doc/qbk/0.main.qbk
@@ -57,7 +57,7 @@
 [def __string_view__            [link url.ref.boost__urls__string_view `string_view`]]
 [def __url__                    [link url.ref.boost__urls__url `url`]]
 [def __url_view__               [link url.ref.boost__urls__url_view `url_view`]]
-[def __grammar__parse__         [link url.ref.boost__urls__grammar__parse `parse_uri`]]
+[def __grammar__parse__         [link url.ref.boost__urls__grammar__parse `parse`]]
 
 [/ Dingbats ]
 

--- a/doc/qbk/4.0.grammars.qbk
+++ b/doc/qbk/4.0.grammars.qbk
@@ -1,0 +1,29 @@
+[/
+    Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com)
+    Copyright (c) 2021 Alan de Freitas (alandefreitas@gmail.com)
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    Official repository: https://github.com/CPPAlliance/url
+]
+
+[section:charset Grammars]
+
+[heading Design of grammar rules]
+
+The function [link url.ref.boost__urls__grammar__parse `parse`] implements the logic for parsing strings
+according to grammar rules.
+
+A grammar rule type, henceforth called a "rule", provides an algorithm for parsing an input string. An
+instance of the rule is used to store the results.
+
+[heading Customization points]
+
+Users can define a free function `parse` as a customization point defining how to parse their
+grammar rules as part of the same architecture that might include arbitrary grammar rules in expressions.
+
+These new function overloads may be defined in other namespaces. As with __std_swap__, the design relies
+on [@https://en.cppreference.com/w/cpp/language/adl argument-dependent lookup] to find these overloads.
+
+[endsect]

--- a/doc/qbk/4.0.grammars.qbk
+++ b/doc/qbk/4.0.grammars.qbk
@@ -8,7 +8,7 @@
     Official repository: https://github.com/CPPAlliance/url
 ]
 
-[section:charset Grammars]
+[section Grammars]
 
 [heading Design of grammar rules]
 


### PR DESCRIPTION
This PR

- fixes a number doxygen warnings and errors
- simplifies the documentation so that docca generates better output
- removes any commands docca cannot render
- includes an exposition for the grammar rule objects
- simplifies the examples
- adjusts the documentation to refer to the grammar namespace
- simplifies descriptions by removing unnecessary and excessive mathematical symbolism
- removes details that are implied from the exposition
- updates parameters to use stock sentences
- removes BOOST_URL_DOCS from overloads and adjusts documentation accordingly