### PR TITLE
Make C++11 requirement explicit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ endif()
 
 function(boost_url_setup_properties target)
     target_compile_features(${target} PUBLIC cxx_constexpr)
+    target_compile_features(${target} PUBLIC cxx_std_11)
     target_compile_definitions(${target} PUBLIC BOOST_URL_NO_LIB=1)
 
     if(BOOST_SUPERPROJECT_VERSION)


### PR DESCRIPTION
This PR makes `cxx_std_11` an explicit requirement at configure stage. If the compiler doesn't support C++11 or  CMAKE_CXX_STANDARD is set to a lower version, the user will be warned about it in the configure step instead of allowing the compiler to try to compile the code and fail. This also improves possible error messages in CI.