### PR TITLE
Update javadoc.hpp guidelines

### DIFF
--- a/doc/javadoc.hpp
+++ b/doc/javadoc.hpp
@@ -10,6 +10,10 @@
 /** {brief}
 
     {description}
+    <!-- Assume the user knows C++ properly -->
+    <!-- Assume the user has read the whole exposition -->
+    <!-- Avoid too much symbolism -->
+    <!-- Avoid repeating words -->
 
     @par Requires
 
@@ -17,21 +21,24 @@
 
     @par Example
     @code
+    {example}
+    // make it short
     @endcode
 
     @note {text}
 
-    @par BNF
-    @code
-    ELEMENT     = {ABNF}
-    @endcode
-
     @par Exception Safety
-    Throws nothing.
-    No-throw guarantee.
-    Strong guarantee.
-    Calls to allocate may throw.
-    Exceptions thrown on invalid input.
+    <!-- exception guarantee + explanation -->
+
+    <!-- Exception guarantee -->
+    Throws nothing. <!-- the function never throws exceptions -->
+    Strong guarantee. <!-- If the function throws an exception, the state of the program is rolled back -->
+    Basic guarantee. <!-- If the function throws an exception, the program is in a valid state -->
+    No guarantee. <!-- If the function throws an exception, the program may not be in a valid state -->
+
+    <!-- Use explanation stock phrases if applicable -->
+    <!-- Calls to allocate may throw. -->
+    <!-- Exceptions thrown on invalid input. -->
 
     @tparam {name} {description}.
 
@@ -39,7 +46,15 @@
 
     @param {name} {description}.
 
-    @throw {exception} {condition}.
+    <!-- Use stock phrases when applicable -->
+    <!-- @param begin An iterator to the beginning of the range -->
+    <!-- @param end An iterator to the end of the range -->
+    <!-- @param ec Set to the error, if any occurred -->
+
+    @throws {exception} {condition}.
+
+    <!-- Use stock phrases when applicable -->
+    <!-- @throws boost::system::system_error Thrown on failure. -->
 
     @par Thread Safety
     {description}
@@ -47,5 +62,12 @@
     @par Specification
     @li <a href="">text (rfc#)</a>
 
-    @see @ref {refid}, @ref {refid}.
+    @par References
+    @li <a href="">text</a>
+
+    @see
+        @ref {refid},
+        @ref {refid},
+        @ref {refid}.
+
 */


### PR DESCRIPTION
This PR extends the javadoc guidelines with some small guidelines and comments that were implicit before but might be useful to any new contributors. These include (i) assumptions about the details, (ii) stock phrases we use in the project, (iii) and how the content of sections should be formatted.