### PR TITLE
params_view::value_type javadocs

### DIFF
--- a/include/boost/url/params_view.hpp
+++ b/include/boost/url/params_view.hpp
@@ -43,6 +43,18 @@ class params_view
 public:
     class iterator;
 
+    /** The value type of query parameters
+
+        The query params object stores a list of encoded string view pairs
+        representing the query parameters identified in the original url.
+
+        When these values are dereference, they are lazily decoded into
+        constant read_only strings in params::reference.
+
+        A special boolean member `has_value` is used to differentiate
+        empty strings from non-existent strings.
+
+    */
     class value_type
     {
     public:


### PR DESCRIPTION
This PR includes javadocs for params_view value type. A few components from javadoc.hpp are still missing in the documentation so this is still a draft.

These files were probably not the best place to start with the javadocs, which is something we could discuss.