### PR TITLE
Prevent CTest unnecessary targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif()
 
 if(BOOST_URL_IS_ROOT)
+    # Prevent CTest added targets
+    set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
     include(CTest)
 endif()
 if(NOT BOOST_SUPERPROJECT_VERSION)


### PR DESCRIPTION
`include(CTest)` includes a number of CMake internal unnecessary targets that clutter the project targets. 

This PR sets the option `set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)` to remove these targets.

Targets we are generating with the option: 

![image](https://user-images.githubusercontent.com/5369819/148824354-dc11e4fd-7a2e-4670-8fb3-afac0e8e74e1.png)

Targets we were generating before:

![image](https://user-images.githubusercontent.com/5369819/148824574-591755eb-1e17-4245-98b6-f6163532fe10.png)




