### PR TITLE
fix warnings

### DIFF
--- a/include/boost/url/authority_view.hpp
+++ b/include/boost/url/authority_view.hpp
@@ -113,7 +113,6 @@ class BOOST_SYMBOL_VISIBLE
             char const* cs) noexcept;
 
     // return offset of id
-    BOOST_URL_CONSTEXPR
     auto
     offset(int id) const noexcept ->
         pos_t
@@ -124,7 +123,6 @@ class BOOST_SYMBOL_VISIBLE
     }
 
     // return length of part
-    BOOST_URL_CONSTEXPR
     auto
     len(int id) const noexcept ->
         pos_t
@@ -135,7 +133,6 @@ class BOOST_SYMBOL_VISIBLE
     }
 
     // return id as string
-    BOOST_URL_CONSTEXPR
     string_view
     get(int id) const noexcept
     {
@@ -144,7 +141,6 @@ class BOOST_SYMBOL_VISIBLE
     }
 
     // return [first, last) as string
-    BOOST_URL_CONSTEXPR
     string_view
     get(int first,
         int last) const noexcept

--- a/include/boost/url/url_view.hpp
+++ b/include/boost/url/url_view.hpp
@@ -137,7 +137,6 @@ protected:
         char const* cs) noexcept;
 
     // return offset of id
-    BOOST_URL_CONSTEXPR
     auto
     offset(int id) const noexcept ->
         pos_t
@@ -148,7 +147,6 @@ protected:
     }
 
     // return length of part
-    BOOST_URL_CONSTEXPR
     auto
     len(int id) const noexcept ->
         pos_t
@@ -159,7 +157,6 @@ protected:
     }
 
     // return id as string
-    BOOST_URL_CONSTEXPR
     string_view
     get(int id) const noexcept
     {
@@ -168,7 +165,6 @@ protected:
     }
 
     // return [first, last) as string
-    BOOST_URL_CONSTEXPR
     string_view
     get(int first,
         int last) const noexcept

--- a/test/unit/pct_encoding.cpp
+++ b/test/unit/pct_encoding.cpp
@@ -357,86 +357,86 @@ public:
     //--------------------------------------------
 
     void
-    testEncode()
+    check( string_view s,
+           string_view m0,
+           bool space_to_plus = false)
     {
-        auto const check =
-            []( string_view s,
-                string_view m0,
-                bool space_to_plus = false)
+        // pct_encode_bytes
         {
-            // pct_encode_bytes
-            {
-                pct_encode_opts opt;
-                opt.space_to_plus =
-                    space_to_plus;
-                BOOST_TEST(pct_encode_bytes(
-                    s, opt, test_chars{}) ==
-                        m0.size());
-            }
-            // pct_encode
-            {
-                pct_encode_opts opt;
-                opt.space_to_plus =
-                    space_to_plus;
-                BOOST_TEST(pct_encode(
-                    s, opt, test_chars{}) == m0);
-            }
-            {
-                static_pool<256> pool;
-                pct_encode_opts opt;
-                opt.space_to_plus =
-                    space_to_plus;
-                BOOST_TEST(pct_encode(
-                    s, opt, test_chars{},
-                        pool.allocator()) == m0);
-            }
-            // pct_encode_to_value
-            {
-                pct_encode_opts opt;
-                opt.space_to_plus =
-                    space_to_plus;
-                BOOST_TEST(pct_encode_to_value(
-                    s, opt, test_chars{}) == m0);
-            }
-            {
-                static_pool<256> pool;
-                pct_encode_opts opt;
-                opt.space_to_plus =
-                    space_to_plus;
-                BOOST_TEST(pct_encode_to_value(
-                    s, opt, test_chars{},
-                        pool.allocator()) == m0);
-            }
             pct_encode_opts opt;
             opt.space_to_plus =
                 space_to_plus;
-            auto const m = pct_encode_to_value(
-                s, opt, test_chars{});
-            if(! BOOST_TEST(m == m0))
-                return;
-            char buf[64];
-            BOOST_ASSERT(
-                m.size() < sizeof(buf));
-            for(std::size_t i = 0;
-                i <= sizeof(buf); ++i)
+            BOOST_TEST(pct_encode_bytes(
+                s, opt, test_chars{}) ==
+                    m0.size());
+        }
+        // pct_encode
+        {
+            pct_encode_opts opt;
+            opt.space_to_plus =
+                space_to_plus;
+            BOOST_TEST(pct_encode(
+                s, opt, test_chars{}) == m0);
+        }
+        {
+            static_pool<256> pool;
+            pct_encode_opts opt;
+            opt.space_to_plus =
+                space_to_plus;
+            BOOST_TEST(pct_encode(
+                s, opt, test_chars{},
+                    pool.allocator()) == m0);
+        }
+        // pct_encode_to_value
+        {
+            pct_encode_opts opt;
+            opt.space_to_plus =
+                space_to_plus;
+            BOOST_TEST(pct_encode_to_value(
+                s, opt, test_chars{}) == m0);
+        }
+        {
+            static_pool<256> pool;
+            pct_encode_opts opt;
+            opt.space_to_plus =
+                space_to_plus;
+            BOOST_TEST(pct_encode_to_value(
+                s, opt, test_chars{},
+                    pool.allocator()) == m0);
+        }
+        pct_encode_opts opt;
+        opt.space_to_plus =
+            space_to_plus;
+        auto const m = pct_encode_to_value(
+            s, opt, test_chars{});
+        if(! BOOST_TEST(m == m0))
+            return;
+        char buf[64];
+        BOOST_ASSERT(
+            m.size() < sizeof(buf));
+        for(std::size_t i = 0;
+            i <= sizeof(buf); ++i)
+        {
+            char* dest = buf;
+            char const* end = buf + i;
+            std::size_t n = pct_encode(
+                dest, end, s, opt, test_chars{});
+            string_view r(buf, n);
+            if(n == m.size())
             {
-                char* dest = buf;
-                char const* end = buf + i;
-                std::size_t n = pct_encode(
-                    dest, end, s, opt, test_chars{});
-                string_view r(buf, n);
-                if(n == m.size())
-                {
-                    BOOST_TEST(i == m.size());
-                    BOOST_TEST(r == m);
-                    break;
-                }
-                BOOST_TEST(
-                    string_view(buf, n) ==
-                    m.substr(0, n));
+                BOOST_TEST(i == m.size());
+                BOOST_TEST(r == m);
+                break;
             }
-        };
+            BOOST_TEST(
+                string_view(buf, n) ==
+                m.substr(0, n));
+        }
+    };
 
+    void
+    testEncode()
+    {
         check("", "");
         check(" ", "%20");
         check("A", "A");


### PR DESCRIPTION
Fixes warnings such as

```
boost/libs/url/include/boost/url/authority_view.hpp:118:5: warning: enclosing class of ‘constexpr’ non-static member function ‘boost::urls::pos_t boost::urls::authority_view::offset(int) const’ is not a literal type
  118 |     offset(int id) const noexcept ->
      |     ^~~~~~
boost/libs/url/include/boost/url/authority_view.hpp:75:5: note: ‘boost::urls::authority_view’ is not literal because:
   75 |     authority_view
      |     ^~~~~~~~~~~~~~
boost/libs/url/include/boost/url/authority_view.hpp:75:5: note:   ‘boost::urls::authority_view’ has a non-trivial destructor
```

```
boost/libs/url/test/unit/url_view.cpp:621:25: warning: default argument specified for lambda parameter [-Wpedantic]
  621 |             char const* encoded = nullptr,
      |             ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
```