### PR TITLE
params assignment

### DIFF
--- a/include/boost/url/params.hpp
+++ b/include/boost/url/params.hpp
@@ -164,13 +164,21 @@ public:
         <!-- @{ -->
      */
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    params&
+    operator=(params const&) & = default;
+
     /** Assignment from initializer list
 
         Assigns @ref params from a list of @ref params::value_type.
 
         Each instance of @ref params::value_type is a view of a query <key, value> pair.
 
-        @return Pointer to this instance of @ref params
+        @return Reference to this instance of @ref params
 
         @param init Initializer list with query parameters
 
@@ -338,6 +346,11 @@ public:
     bool
     empty() const noexcept;
 
+    /** Return the number of elements
+
+        @return Number of elements in the container
+
+     */
     inline
     std::size_t
     size() const noexcept;

--- a/include/boost/url/params_encoded.hpp
+++ b/include/boost/url/params_encoded.hpp
@@ -84,6 +84,14 @@ public:
      *  <!-- @{ -->
      */
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    params_encoded&
+    operator=(params_encoded const&) & = default;
+
     /** Assignment from initializer list
 
         Assign params from a list of param value_type.

--- a/include/boost/url/params_encoded_view.hpp
+++ b/include/boost/url/params_encoded_view.hpp
@@ -144,6 +144,14 @@ public:
     params_view
     decoded(Allocator const& alloc = {}) const;
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    params_encoded_view&
+    operator=(params_encoded_view const&) & = default;
+
     //--------------------------------------------
     //
     // Element Access

--- a/include/boost/url/params_view.hpp
+++ b/include/boost/url/params_view.hpp
@@ -94,6 +94,14 @@ public:
     using size_type = std::size_t;
     using difference_type = std::ptrdiff_t;
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    params_view&
+    operator=(params_view const&) & = default;
+
     //--------------------------------------------
     //
     // Element Access

--- a/include/boost/url/query_param.hpp
+++ b/include/boost/url/query_param.hpp
@@ -85,7 +85,7 @@ struct query_param_view
     `has_value == true`.
     A value that is present with an empty string
     is distinct from a value that is absent.
-    Whether the strings are precent-encoded
+    Whether the strings are percent-encoded
     is determined by the container from which
     the value is obtained.
 */

--- a/include/boost/url/segments.hpp
+++ b/include/boost/url/segments.hpp
@@ -126,6 +126,14 @@ public:
     bool
     is_absolute() const noexcept;
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    segments&
+    operator=(segments const&) & = default;
+
     /** Replace the contents of the container
 
         This function replaces the contents with

--- a/include/boost/url/segments_encoded.hpp
+++ b/include/boost/url/segments_encoded.hpp
@@ -132,6 +132,14 @@ public:
     segments
     decoded(Allocator const& alloc = {}) const;
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    segments_encoded&
+    operator=(segments_encoded const&) & = default;
+
     /** Replace the contents of the container
 
         This function replaces the contents

--- a/include/boost/url/segments_encoded_view.hpp
+++ b/include/boost/url/segments_encoded_view.hpp
@@ -140,6 +140,14 @@ public:
     inline
     segments_encoded_view() noexcept;
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    segments_encoded_view&
+    operator=(segments_encoded_view const&) & = default;
+
     /** Return a view of this container as percent-decoded segments
 
         This function returns a new view over the

--- a/include/boost/url/segments_view.hpp
+++ b/include/boost/url/segments_view.hpp
@@ -86,6 +86,15 @@ public:
     inline
     segments_view() noexcept;
 
+    /** Assignment
+
+        After the assignment, both views will point to
+        the same underlying object.
+    */
+    segments_view&
+    operator=(segments_view const& other) & = default;
+
+
     /** Returns true if this contains an absolute path.
 
         Absolute paths always start with a

--- a/test/unit/params.cpp
+++ b/test/unit/params.cpp
@@ -26,6 +26,16 @@ public:
     void
     testMembers()
     {
+        // operator=(params const&)
+        {
+            url u1;
+            url u2;
+            params p1 = u1.params();
+            params p2 = u2.params();
+            p2 = p1;
+            BOOST_TEST(p1.begin() == p2.begin());
+        }
+
         // operator=
         // assign(initializer_list)
         // assign(FwdIt, FwdIt)

--- a/test/unit/params_encoded.cpp
+++ b/test/unit/params_encoded.cpp
@@ -22,6 +22,16 @@ public:
     void
     testMembers()
     {
+        // operator=(params_encoded const&)
+        {
+            url u1;
+            url u2;
+            params_encoded p1 = u1.encoded_params();
+            params_encoded p2 = u2.encoded_params();
+            p2 = p1;
+            BOOST_TEST(p1.begin() == p2.begin());
+        }
+
         // operator=
         // assign(initializer_list)
         // assign(FwdIt, FwdIt)

--- a/test/unit/params_encoded_view.cpp
+++ b/test/unit/params_encoded_view.cpp
@@ -21,6 +21,20 @@ class params_encoded_view_test
 {
 public:
     void
+    testMembers()
+    {
+        // operator=(params_encoded_view const&)
+        {
+            url_view u1;
+            url_view u2;
+            params_encoded_view p1 = u1.encoded_params();
+            params_encoded_view p2 = u2.encoded_params();
+            p2 = p1;
+            BOOST_TEST(p1.begin() == p2.begin());
+        }
+    }
+
+    void
     testElements()
     {
         // at(string_view)
@@ -190,6 +204,7 @@ public:
     void
     run()
     {
+        testMembers();
         testElements();
         testCapacity();
         testLookup();

--- a/test/unit/params_view.cpp
+++ b/test/unit/params_view.cpp
@@ -24,6 +24,20 @@ public:
     pool_t pa;
 
     void
+    testMembers()
+    {
+        // operator=(params_view const&)
+        {
+            url_view u1;
+            url_view u2;
+            params_view p1 = u1.params();
+            params_view p2 = u2.params();
+            p2 = p1;
+            BOOST_TEST(p1.begin() == p2.begin());
+        }
+    }
+
+    void
     testElements()
     {
         // at(string_view)
@@ -181,6 +195,7 @@ public:
     void
     run()
     {
+        testMembers();
         testElements();
         testCapacity();
         testLookup();

--- a/test/unit/segments.cpp
+++ b/test/unit/segments.cpp
@@ -45,6 +45,16 @@ public:
     void
     testMembers()
     {
+        // operator=(segments const&)
+        {
+            url u1;
+            url u2;
+            segments p1 = u1.segments();
+            segments p2 = u2.segments();
+            p2 = p1;
+            BOOST_TEST(p1.begin() == p2.begin());
+        }
+
         url_view const u0 = parse_uri(
             "x://y/path/to/the/file.txt?q#f").value();
 

--- a/test/unit/segments_encoded.cpp
+++ b/test/unit/segments_encoded.cpp
@@ -40,6 +40,16 @@ public:
     void
     testMembers()
     {
+        // operator=(segments const&)
+        {
+            url u1;
+            url u2;
+            segments_encoded p1 = u1.encoded_segments();
+            segments_encoded p2 = u2.encoded_segments();
+            p2 = p1;
+            BOOST_TEST(p1.begin() == p2.begin());
+        }
+
         url_view const u0 = parse_uri(
             "x://y/path/to/the/file.txt?q#f").value();
 

--- a/test/unit/segments_encoded_view.cpp
+++ b/test/unit/segments_encoded_view.cpp
@@ -101,6 +101,14 @@ public:
                 sv.begin() == sv.end());
         }
 
+        // operator=(segments_view const&)
+        {
+            segments_encoded_view s1;
+            segments_encoded_view s2;
+            s1 = s2;
+            BOOST_TEST(s1.begin() == s2.begin());
+        }
+
         // decoded
         {
             segments_encoded_view sev = parse_path(

--- a/test/unit/segments_view.cpp
+++ b/test/unit/segments_view.cpp
@@ -121,6 +121,14 @@ public:
                 sv.begin() == sv.end());
         }
 
+        // operator=(segments_view const&)
+        {
+            segments_view s1;
+            segments_view s2;
+            s1 = s2;
+            BOOST_TEST(s1.begin() == s2.begin());
+        }
+
         // decoded
         {
             segments_view sv = parse_path(


### PR DESCRIPTION
Fixes #77 

This PR prevents rvalue assignment from compiling:

```cpp
u1.params() = u2.params();
```

while still allowing lvalue assignment to compile:

```cpp
auto p = u1.params();
p = u2.params();
```

