### PR TITLE
tag_invoke hidden friendship (fix #99)

### DIFF
--- a/doc/qbk/0.main.qbk
+++ b/doc/qbk/0.main.qbk
@@ -45,7 +45,7 @@
 [def __MoveConstructible__      [@https://en.cppreference.com/w/cpp/named_req/MoveConstructible ['MoveConstructible]]]
 [def __SemiRegular__            [@https://en.cppreference.com/w/cpp/concepts/semiregular ['SemiRegular]]]
 [def __Swappable__              [@https://en.cppreference.com/w/cpp/named_req/Swappable ['Swappable]]]
-[def __CharSet__                [link url.grammars_rules.charset ['CharSet]]]
+[def __CharSet__                [link url.grammar_rules.charset ['CharSet]]]
 
 [def __std_swap__               [@https://en.cppreference.com/w/cpp/algorithm/swap `std::swap`]]
 [def __authority_view__         [link url.ref.boost__urls__authority_view `authority_view`]]
@@ -88,7 +88,7 @@
 
 [include 4.0.modifying.qbk]
 
-[section Grammars Rules]
+[section Grammar Rules]
 [include 5.0.grammars.qbk]
 [include 5.1.customization.qbk]
 [include 5.2.CharSet.qbk]

--- a/doc/qbk/5.1.customization.qbk
+++ b/doc/qbk/5.1.customization.qbk
@@ -8,11 +8,10 @@
     Official repository: https://github.com/CPPAlliance/url
 ]
 
-[section Customization points]
+[section Customization Point]
 
-Users can define customization points defining the logic to parse and store the results of
+Users can define customization points with the logic to parse and store the results of
 grammar rules as part of the same library architecture.
-
 This allows arbitrary grammar logic in expressions that interact with the existing rules.
 Some use cases could include alternative or extended syntax for URLs and its components.
 
@@ -21,7 +20,11 @@ customization point.
 
 [snippet_customization_1]
 
-The function [link url.ref.boost__urls__grammar__parse `parse`] relies on
+The `tag_invoke` customization points are defined as a
+[@http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1601r0.pdf hidden friend] of the rule object.
+Thus, the befriended `tag_invoke` overload should be fully defined within the class synopsis.
+
+This means the function [link url.ref.boost__urls__grammar__parse `parse`] can only rely on
 [@https://en.cppreference.com/w/cpp/language/adl argument-dependent lookup] to find these function
 overloads with the appropriate tag [link url.ref.boost__urls__grammar__parse_tag `grammar::parse_tag`].
 

--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -106,7 +106,7 @@
         </simplelist>
         <bridgehead renderas="sect3">Concepts</bridgehead>
         <simplelist type="vert" columns="1">
-          <member><link linkend="url.grammars_rules.charset"><emphasis>CharSet</emphasis></link></member>
+          <member><link linkend="url.grammar_rules.charset"><emphasis>CharSet</emphasis></link></member>
         </simplelist>
       </entry>
     </row></tbody>

--- a/include/boost/url/grammar/impl/range.hpp
+++ b/include/boost/url/grammar/impl/range.hpp
@@ -72,18 +72,6 @@ range_(T const*) noexcept
         is_range<T>::value);
 }
 
-inline
-void
-tag_invoke(
-    parse_tag const&,
-    char const*& it,
-    char const* end,
-    error_code& ec,
-    range_& t)
-{
-    t.fp_(it, end, ec, t);
-}
-
 //------------------------------------------------
 
 template<class R>

--- a/include/boost/url/grammar/range.hpp
+++ b/include/boost/url/grammar/range.hpp
@@ -102,7 +102,10 @@ public:
         char const*& it,
         char const* end,
         error_code& ec,
-        range_& t);
+        range_& t)
+    {
+        t.fp_(it, end, ec, t);
+    }
 };
 
 //------------------------------------------------

--- a/include/boost/url/impl/ipv4_address.ipp
+++ b/include/boost/url/impl/ipv4_address.ipp
@@ -107,8 +107,8 @@ is_multicast() const noexcept
 }
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+ipv4_address::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,

--- a/include/boost/url/impl/ipv6_address.ipp
+++ b/include/boost/url/impl/ipv6_address.ipp
@@ -318,8 +318,8 @@ print_impl(
 }
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+ipv6_address::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,

--- a/include/boost/url/ipv4_address.hpp
+++ b/include/boost/url/ipv4_address.hpp
@@ -263,15 +263,28 @@ public:
     /** Customization point for parsing an IPv4 address.
     */
     BOOST_URL_DECL
+    friend
     void
     tag_invoke(
         grammar::parse_tag const&,
         char const*& it,
         char const* const end,
         error_code& ec,
-        ipv4_address& t) noexcept;
+        ipv4_address& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
 
 private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
+        ipv4_address& t) noexcept;
+
     friend class ipv6_address;
 
     BOOST_URL_DECL

--- a/include/boost/url/ipv6_address.hpp
+++ b/include/boost/url/ipv6_address.hpp
@@ -325,9 +325,21 @@ public:
         char const*& it,
         char const* const end,
         error_code& ec,
-        ipv6_address& t) noexcept;
+        ipv6_address& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
 
 private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
+        ipv6_address& t) noexcept;
+
     BOOST_URL_DECL
     std::size_t
     print_impl(

--- a/include/boost/url/rfc/impl/paths_rule.ipp
+++ b/include/boost/url/rfc/impl/paths_rule.ipp
@@ -19,8 +19,8 @@ namespace boost {
 namespace urls {
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+segment_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,
@@ -36,8 +36,8 @@ tag_invoke(
 //------------------------------------------------
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+segment_nz_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,
@@ -59,8 +59,8 @@ tag_invoke(
 //------------------------------------------------
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+segment_nz_nc_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,

--- a/include/boost/url/rfc/impl/port_rule.ipp
+++ b/include/boost/url/rfc/impl/port_rule.ipp
@@ -21,8 +21,8 @@ namespace boost {
 namespace urls {
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+port_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,
@@ -63,12 +63,12 @@ tag_invoke(
 }
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+port_part_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,
-    port_part_rule& t)
+    port_part_rule& t) noexcept
 {
     if( it == end ||
         *it != ':')

--- a/include/boost/url/rfc/impl/query_rule.ipp
+++ b/include/boost/url/rfc/impl/query_rule.ipp
@@ -135,8 +135,8 @@ increment(
 //------------------------------------------------
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+query_part_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,

--- a/include/boost/url/rfc/impl/reg_name_rule.ipp
+++ b/include/boost/url/rfc/impl/reg_name_rule.ipp
@@ -31,8 +31,8 @@ namespace urls {
     the complete domain name and some local domain.
 */
 void
-tag_invoke(
-    grammar::parse_tag const&,
+reg_name_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,

--- a/include/boost/url/rfc/impl/scheme_rule.ipp
+++ b/include/boost/url/rfc/impl/scheme_rule.ipp
@@ -53,8 +53,8 @@ parse(
 }
 
 void
-tag_invoke(
-    grammar::parse_tag const&,
+scheme_part_rule::
+parse(
     char const*& it,
     char const* const end,
     error_code& ec,

--- a/include/boost/url/rfc/paths_rule.hpp
+++ b/include/boost/url/rfc/paths_rule.hpp
@@ -62,7 +62,6 @@ struct segment_rule
 {
     pct_encoded_str& v;
 
-    BOOST_URL_DECL
     friend
     void
     tag_invoke(
@@ -70,7 +69,21 @@ struct segment_rule
         char const*& it,
         char const* const end,
         error_code& ec,
+        segment_rule const& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
         segment_rule const& t) noexcept;
+
 };
 #endif
 
@@ -103,11 +116,23 @@ struct segment_nz_rule
 {
     pct_encoded_str& v;
 
-    BOOST_URL_DECL
     friend
     void
     tag_invoke(
         grammar::parse_tag const&,
+        char const*& it,
+        char const* const end,
+        error_code& ec,
+        segment_nz_rule const& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
         char const*& it,
         char const* const end,
         error_code& ec,
@@ -147,7 +172,6 @@ struct segment_nz_nc_rule
 {
     pct_encoded_str& v;
 
-    BOOST_URL_DECL
     friend
     void
     tag_invoke(
@@ -155,7 +179,22 @@ struct segment_nz_nc_rule
         char const*& it,
         char const* const end,
         error_code& ec,
+        segment_nz_nc_rule const& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
         segment_nz_nc_rule const& t) noexcept;
+
+
 };
 #endif
 

--- a/include/boost/url/rfc/port_rule.hpp
+++ b/include/boost/url/rfc/port_rule.hpp
@@ -42,7 +42,6 @@ struct port_rule
     std::uint16_t number;
     bool has_number = false;
 
-    BOOST_URL_DECL
     friend
     void
     tag_invoke(
@@ -50,7 +49,21 @@ struct port_rule
         char const*& it,
         char const* const end,
         error_code& ec,
+        port_rule& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
         port_rule& t) noexcept;
+
 };
 
 /** Rule for port-part
@@ -79,14 +92,27 @@ struct port_part_rule
     bool has_number = false;
     std::uint16_t port_number = 0;
 
-    BOOST_URL_DECL
     friend
-    bool
+    void
+    tag_invoke(
+        grammar::parse_tag const&,
+        char const*& it,
+        char const* const end,
+        error_code& ec,
+        port_part_rule& t)
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
     parse(
         char const*& it,
         char const* const end,
         error_code& ec,
-        port_part_rule& t);
+        port_part_rule& t) noexcept;
 };
 
 } // urls

--- a/include/boost/url/rfc/query_rule.hpp
+++ b/include/boost/url/rfc/query_rule.hpp
@@ -112,7 +112,6 @@ struct query_part_rule
     query_rule query;
     string_view query_part;
 
-    BOOST_URL_DECL
     friend
     void
     tag_invoke(
@@ -120,7 +119,21 @@ struct query_part_rule
         char const*& it,
         char const* const end,
         error_code& ec,
+        query_part_rule& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
         query_part_rule& t) noexcept;
+
 };
 
 } // urls

--- a/include/boost/url/rfc/reg_name_rule.hpp
+++ b/include/boost/url/rfc/reg_name_rule.hpp
@@ -44,6 +44,19 @@ struct reg_name_rule
         char const*& it,
         char const* const end,
         error_code& ec,
+        reg_name_rule& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
         reg_name_rule& t) noexcept;
 };
 

--- a/include/boost/url/rfc/scheme_rule.hpp
+++ b/include/boost/url/rfc/scheme_rule.hpp
@@ -84,7 +84,6 @@ struct scheme_part_rule
         urls::scheme::none;
     string_view scheme_part;
 
-    BOOST_URL_DECL
     friend
     void
     tag_invoke(
@@ -92,7 +91,21 @@ struct scheme_part_rule
         char const*& it,
         char const* const end,
         error_code& ec,
+        scheme_part_rule& t) noexcept
+    {
+        parse(it, end, ec, t);
+    }
+
+private:
+    BOOST_URL_DECL
+    static
+    void
+    parse(
+        char const*& it,
+        char const* const end,
+        error_code& ec,
         scheme_part_rule& t) noexcept;
+
 };
 
 } // urls


### PR DESCRIPTION
This PR defines the befriended `tag_invoke` functions fully within the class synopsis so that they are hidden friends accessible through ADL only.