### PR TITLE
move inline declarations from the class body

### DIFF
--- a/include/boost/url/authority_view.hpp
+++ b/include/boost/url/authority_view.hpp
@@ -102,9 +102,9 @@ class BOOST_SYMBOL_VISIBLE
 
     struct shared_impl;
 
-    inline pos_t len(int first,
+    pos_t len(int first,
         int last) const noexcept;
-    inline void set_size(
+    void set_size(
         int id, pos_t n) noexcept;
     explicit authority_view(
         char const* cs) noexcept;

--- a/include/boost/url/impl/authority_view.hpp
+++ b/include/boost/url/impl/authority_view.hpp
@@ -14,6 +14,7 @@ namespace boost {
 namespace urls {
 
 // return length of [first, last)
+inline
 auto
 authority_view::
 len(
@@ -27,6 +28,7 @@ len(
 }
 
 // change id to size n
+inline
 void
 authority_view::
 set_size(

--- a/include/boost/url/impl/params.hpp
+++ b/include/boost/url/impl/params.hpp
@@ -235,6 +235,7 @@ params(
 {
 }
 
+inline
 params&
 params::
 operator=(std::initializer_list<
@@ -244,6 +245,7 @@ operator=(std::initializer_list<
     return *this;
 }
 
+inline
 void
 params::
 assign(std::initializer_list<
@@ -285,10 +287,11 @@ assign(FwdIt first, FwdIt last,
 //
 //------------------------------------------------
 
+inline
 auto
 params::
 at(std::size_t pos) const ->
-    reference
+    const_reference
 {
     if(pos >= size())
         detail::throw_out_of_range(
@@ -296,6 +299,7 @@ at(std::size_t pos) const ->
     return (*this)[pos];
 }
 
+inline
 auto
 params::
 front() const ->
@@ -305,6 +309,7 @@ front() const ->
     return (*this)[0];
 }
 
+inline
 auto
 params::
 back() const ->
@@ -320,6 +325,7 @@ back() const ->
 //
 //--------------------------------------------
 
+inline
 auto
 params::
 begin() const noexcept ->
@@ -328,6 +334,7 @@ begin() const noexcept ->
     return { *u_, 0, a_ };
 }
 
+inline
 auto
 params::
 end() const noexcept ->
@@ -342,6 +349,7 @@ end() const noexcept ->
 //
 //------------------------------------------------
 
+inline
 std::size_t
 params::
 size() const noexcept
@@ -349,6 +357,7 @@ size() const noexcept
     return u_->nparam_;
 }
 
+inline
 bool
 params::
 empty() const noexcept
@@ -362,6 +371,7 @@ empty() const noexcept
 //
 //------------------------------------------------
 
+inline
 void
 params::
 clear() noexcept
@@ -371,6 +381,7 @@ clear() noexcept
 
 //------------------------------------------------
 
+inline
 auto
 params::
 insert(
@@ -382,6 +393,7 @@ insert(
         before, &v, &v + 1);
 }
 
+inline
 auto
 params::
 insert(
@@ -433,6 +445,7 @@ insert(
 
 //------------------------------------------------
 
+inline
 auto
 params::
 replace(
@@ -471,6 +484,7 @@ replace(
     return from;
 }
 
+inline
 auto
 params::
 replace(
@@ -489,6 +503,7 @@ replace(
 
 //------------------------------------------------
 
+inline
 auto
 params::
 emplace_at(
@@ -512,6 +527,7 @@ emplace_at(
     return pos;
 }
 
+inline
 auto
 params::
 emplace_at(
@@ -532,6 +548,7 @@ emplace_at(
     return pos;
 }
 
+inline
 auto
 params::
 emplace_before(
@@ -548,6 +565,7 @@ emplace_before(
             true});
 }
 
+inline
 auto
 params::
 emplace_before(
@@ -565,6 +583,7 @@ emplace_before(
 
 //------------------------------------------------
 
+inline
 auto
 params::
 erase(iterator pos) ->
@@ -575,6 +594,7 @@ erase(iterator pos) ->
 
 //------------------------------------------------
 
+inline
 auto
 params::
 emplace_back(
@@ -586,6 +606,7 @@ emplace_back(
             key, {}, false});
 }
 
+inline
 auto
 params::
 emplace_back(
@@ -598,6 +619,7 @@ emplace_back(
             key, value, true});
 }
 
+inline
 void
 params::
 push_back(
@@ -606,7 +628,7 @@ push_back(
     insert(end(), v);
 }
 
-
+inline
 void
 params::
 pop_back() noexcept
@@ -620,6 +642,7 @@ pop_back() noexcept
 //
 //------------------------------------------------
 
+inline
 auto
 params::
 find(string_view key) const noexcept ->
@@ -628,6 +651,7 @@ find(string_view key) const noexcept ->
     return find(begin(), key);
 }
 
+inline
 bool
 params::
 contains(string_view key) const noexcept

--- a/include/boost/url/impl/params_encoded.hpp
+++ b/include/boost/url/impl/params_encoded.hpp
@@ -218,6 +218,7 @@ public:
 //
 //------------------------------------------------
 
+inline
 params_encoded::
 params_encoded(
     url& u) noexcept
@@ -225,6 +226,7 @@ params_encoded(
 {
 }
 
+inline
 params_encoded&
 params_encoded::
 operator=(std::initializer_list<
@@ -234,6 +236,7 @@ operator=(std::initializer_list<
     return *this;
 }
 
+inline
 void
 params_encoded::
 assign(std::initializer_list<
@@ -283,6 +286,7 @@ decoded(Allocator const& alloc) const
 //
 //------------------------------------------------
 
+inline
 auto
 params_encoded::
 at(std::size_t pos) const ->
@@ -294,6 +298,7 @@ at(std::size_t pos) const ->
     return (*this)[pos];
 }
 
+inline
 auto
 params_encoded::
 front() const ->
@@ -303,6 +308,7 @@ front() const ->
     return (*this)[0];
 }
 
+inline
 auto
 params_encoded::
 back() const ->
@@ -318,6 +324,7 @@ back() const ->
 //
 //--------------------------------------------
 
+inline
 auto
 params_encoded::
 begin() const noexcept ->
@@ -326,6 +333,7 @@ begin() const noexcept ->
     return { *u_, 0 };
 }
 
+inline
 auto
 params_encoded::
 end() const noexcept ->
@@ -340,6 +348,7 @@ end() const noexcept ->
 //
 //------------------------------------------------
 
+inline
 bool
 params_encoded::
 empty() const noexcept
@@ -347,6 +356,7 @@ empty() const noexcept
     return size() == 0;
 }
 
+inline
 std::size_t
 params_encoded::
 size() const noexcept
@@ -360,6 +370,7 @@ size() const noexcept
 //
 //------------------------------------------------
 
+inline
 void
 params_encoded::
 clear() noexcept
@@ -369,6 +380,7 @@ clear() noexcept
 
 //------------------------------------------------
 
+inline
 auto
 params_encoded::
 insert(
@@ -380,6 +392,7 @@ insert(
         before, &v, &v + 1);
 }
 
+inline
 auto
 params_encoded::
 insert(
@@ -431,6 +444,7 @@ insert(
 
 //------------------------------------------------
 
+inline
 auto
 params_encoded::
 replace(
@@ -469,6 +483,7 @@ replace(
     return from;
 }
 
+inline
 auto
 params_encoded::
 replace(
@@ -487,6 +502,7 @@ replace(
 
 //------------------------------------------------
 
+inline
 auto
 params_encoded::
 emplace_at(
@@ -510,6 +526,7 @@ emplace_at(
     return pos;
 }
 
+inline
 auto
 params_encoded::
 emplace_back(
@@ -521,6 +538,7 @@ emplace_back(
             key, {}, false});
 }
 
+inline
 auto
 params_encoded::
 emplace_back(
@@ -533,6 +551,7 @@ emplace_back(
             key, value, true});
 }
 
+inline
 auto
 params_encoded::
 emplace_at(
@@ -555,6 +574,7 @@ emplace_at(
     return pos;
 }
 
+inline
 auto
 params_encoded::
 emplace_before(
@@ -571,6 +591,7 @@ emplace_before(
             true});
 }
 
+inline
 auto
 params_encoded::
 emplace_before(
@@ -588,6 +609,7 @@ emplace_before(
 
 //------------------------------------------------
 
+inline
 auto
 params_encoded::
 erase(iterator pos) ->
@@ -598,6 +620,7 @@ erase(iterator pos) ->
 
 //------------------------------------------------
 
+inline
 void
 params_encoded::
 push_back(
@@ -606,6 +629,7 @@ push_back(
     insert(end(), v);
 }
 
+inline
 void
 params_encoded::
 pop_back() noexcept
@@ -619,6 +643,7 @@ pop_back() noexcept
 //
 //------------------------------------------------
 
+inline
 auto
 params_encoded::
 find(string_view key) const noexcept ->
@@ -627,6 +652,7 @@ find(string_view key) const noexcept ->
     return find(begin(), key);
 }
 
+inline
 bool
 params_encoded::
 contains(string_view key) const noexcept

--- a/include/boost/url/impl/params_encoded_view.hpp
+++ b/include/boost/url/impl/params_encoded_view.hpp
@@ -90,6 +90,7 @@ public:
 //
 //------------------------------------------------
 
+inline
 params_encoded_view::
 params_encoded_view(
     string_view s,
@@ -113,6 +114,7 @@ decoded(Allocator const& alloc) const
 //
 //------------------------------------------------
 
+inline
 bool
 params_encoded_view::
 empty() const noexcept
@@ -120,6 +122,7 @@ empty() const noexcept
     return n_ == 0;
 }
 
+inline
 std::size_t
 params_encoded_view::
 size() const noexcept
@@ -133,6 +136,7 @@ size() const noexcept
 //
 //------------------------------------------------
 
+inline
 auto
 params_encoded_view::
 find(string_view key) const noexcept ->
@@ -141,6 +145,7 @@ find(string_view key) const noexcept ->
     return find(begin(), key);
 }
 
+inline
 bool
 params_encoded_view::
 contains(string_view key) const noexcept

--- a/include/boost/url/impl/params_view.hpp
+++ b/include/boost/url/impl/params_view.hpp
@@ -111,6 +111,7 @@ params_view(
 //
 //------------------------------------------------
 
+inline
 bool
 params_view::
 empty() const noexcept
@@ -118,6 +119,7 @@ empty() const noexcept
     return n_ == 0;
 }
 
+inline
 std::size_t
 params_view::
 size() const noexcept
@@ -131,6 +133,7 @@ size() const noexcept
 //
 //------------------------------------------------
 
+inline
 auto
 params_view::
 find(string_view key) const noexcept ->
@@ -139,6 +142,7 @@ find(string_view key) const noexcept ->
     return find(begin(), key);
 }
 
+inline
 bool
 params_view::
 contains(

--- a/include/boost/url/impl/segments.hpp
+++ b/include/boost/url/impl/segments.hpp
@@ -225,6 +225,7 @@ segments(
 {
 }
 
+inline
 bool
 segments::
 is_absolute() const noexcept
@@ -234,6 +235,7 @@ is_absolute() const noexcept
         u_->s_[u_->offset(id_path)] == '/';
 }
 
+inline
 segments&
 segments::
 operator=(std::initializer_list<
@@ -268,6 +270,7 @@ assign(FwdIt first, FwdIt last) ->
 //
 //------------------------------------------------
 
+inline
 auto
 segments::
 at(std::size_t i) const ->
@@ -279,6 +282,7 @@ at(std::size_t i) const ->
     return (*this)[i];
 }
 
+inline
 auto
 segments::
 front() const ->
@@ -288,6 +292,7 @@ front() const ->
     return (*this)[0];
 }
 
+inline
 auto
 segments::
 back() const ->
@@ -303,6 +308,7 @@ back() const ->
 //
 //------------------------------------------------
 
+inline
 auto
 segments::
 begin() const noexcept ->
@@ -312,6 +318,7 @@ begin() const noexcept ->
         *u_, 0, a_);
 }
 
+inline
 auto
 segments::
 end() const noexcept ->
@@ -327,6 +334,7 @@ end() const noexcept ->
 //
 //------------------------------------------------
 
+inline
 bool
 segments::
 empty() const noexcept
@@ -334,6 +342,7 @@ empty() const noexcept
     return size() == 0;
 }
 
+inline
 std::size_t
 segments::
 size() const noexcept
@@ -347,6 +356,7 @@ size() const noexcept
 //
 //------------------------------------------------
 
+inline
 void
 segments::
 clear() noexcept
@@ -356,6 +366,7 @@ clear() noexcept
 
 //------------------------------------------------
 
+inline
 auto
 segments::
 insert(
@@ -411,6 +422,7 @@ insert(
 
 //------------------------------------------------
 
+inline
 auto
 segments::
 replace(
@@ -423,6 +435,7 @@ replace(
             &s, &s + 1);
 }
 
+inline
 auto
 segments::
 replace(
@@ -468,6 +481,7 @@ replace(
 
 //------------------------------------------------
 
+inline
 auto
 segments::
 erase(
@@ -479,6 +493,7 @@ erase(
 
 //------------------------------------------------
 
+inline
 void
 segments::
 push_back(
@@ -487,6 +502,7 @@ push_back(
     insert(end(), s);
 }
 
+inline
 void
 segments::
 pop_back() noexcept

--- a/include/boost/url/impl/segments_encoded.hpp
+++ b/include/boost/url/impl/segments_encoded.hpp
@@ -204,6 +204,7 @@ public:
 //
 //------------------------------------------------
 
+inline
 segments_encoded::
 segments_encoded(
     url& u) noexcept
@@ -211,6 +212,7 @@ segments_encoded(
 {
 }
 
+inline
 bool
 segments_encoded::
 is_absolute() const noexcept
@@ -228,6 +230,7 @@ decoded(Allocator const& alloc) const
     return segments(*u_, alloc);
 }
 
+inline
 segments_encoded&
 segments_encoded::
 operator=(std::initializer_list<string_view> init)
@@ -260,6 +263,7 @@ assign(
 //
 //------------------------------------------------
 
+inline
 string_view
 segments_encoded::
 at(std::size_t i) const
@@ -270,6 +274,7 @@ at(std::size_t i) const
     return (*this)[i];
 }
 
+inline
 string_view
 segments_encoded::
 front() const noexcept
@@ -278,6 +283,7 @@ front() const noexcept
     return (*this)[0];
 }
 
+inline
 string_view
 segments_encoded::
 back() const noexcept
@@ -292,6 +298,7 @@ back() const noexcept
 //
 //------------------------------------------------
 
+inline
 auto
 segments_encoded::
 begin() const noexcept ->
@@ -300,6 +307,7 @@ begin() const noexcept ->
     return iterator(*u_, 0);
 }
 
+inline
 auto
 segments_encoded::
 end() const noexcept ->
@@ -314,6 +322,7 @@ end() const noexcept ->
 //
 //------------------------------------------------
 
+inline
 bool
 segments_encoded::
 empty() const noexcept
@@ -321,6 +330,7 @@ empty() const noexcept
     return size() == 0;
 }
 
+inline
 std::size_t
 segments_encoded::
 size() const noexcept
@@ -334,6 +344,7 @@ size() const noexcept
 //
 //------------------------------------------------
 
+inline
 void
 segments_encoded::
 clear() noexcept
@@ -343,6 +354,7 @@ clear() noexcept
 
 //------------------------------------------------
 
+inline
 auto
 segments_encoded::
 insert(
@@ -398,6 +410,7 @@ insert(
 
 //------------------------------------------------
 
+inline
 auto
 segments_encoded::
 replace(
@@ -410,6 +423,7 @@ replace(
             &s, &s + 1);
 }
 
+inline
 auto
 segments_encoded::
 replace(
@@ -453,6 +467,7 @@ replace(
 
 //------------------------------------------------
 
+inline
 auto
 segments_encoded::
 erase(
@@ -464,6 +479,7 @@ erase(
 
 //------------------------------------------------
 
+inline
 void
 segments_encoded::
 push_back(
@@ -472,6 +488,7 @@ push_back(
     insert(end(), s);
 }
 
+inline
 void
 segments_encoded::
 pop_back() noexcept

--- a/include/boost/url/impl/segments_encoded_view.hpp
+++ b/include/boost/url/impl/segments_encoded_view.hpp
@@ -109,6 +109,7 @@ public:
 //
 //------------------------------------------------
 
+inline
 segments_encoded_view::
 segments_encoded_view() noexcept
     : s_("")
@@ -124,6 +125,7 @@ decoded(Allocator const& alloc) const
     return segments_view(s_, n_, alloc);
 }
 
+inline
 bool
 segments_encoded_view::
 is_absolute() const noexcept
@@ -137,6 +139,7 @@ is_absolute() const noexcept
 //
 //------------------------------------------------
 
+inline
 string_view
 segments_encoded_view::
 front() const noexcept
@@ -145,6 +148,7 @@ front() const noexcept
     return *begin();
 }
 
+inline
 string_view
 segments_encoded_view::
 back() const noexcept
@@ -159,6 +163,7 @@ back() const noexcept
 //
 //------------------------------------------------
 
+inline
 bool
 segments_encoded_view::
 empty() const noexcept
@@ -166,6 +171,7 @@ empty() const noexcept
     return size() == 0;
 }
 
+inline
 std::size_t
 segments_encoded_view::
 size() const noexcept

--- a/include/boost/url/impl/segments_view.hpp
+++ b/include/boost/url/impl/segments_view.hpp
@@ -128,9 +128,11 @@ segments_view(
 {
 }
 
+inline
 segments_view::
 segments_view() noexcept = default;
 
+inline
 bool
 segments_view::
 is_absolute() const noexcept
@@ -144,6 +146,7 @@ is_absolute() const noexcept
 //
 //------------------------------------------------
 
+inline
 const_string
 segments_view::
 front() const noexcept
@@ -152,6 +155,7 @@ front() const noexcept
     return *begin();
 }
 
+inline
 const_string
 segments_view::
 back() const noexcept
@@ -166,6 +170,7 @@ back() const noexcept
 //
 //------------------------------------------------
 
+inline
 bool
 segments_view::
 empty() const noexcept
@@ -173,6 +178,7 @@ empty() const noexcept
     return size() == 0;
 }
 
+inline
 std::size_t
 segments_view::
 size() const noexcept

--- a/include/boost/url/impl/url_view.hpp
+++ b/include/boost/url/impl/url_view.hpp
@@ -13,6 +13,7 @@
 namespace boost {
 namespace urls {
 
+inline
 url_view&
 url_view::
 base() noexcept
@@ -20,6 +21,7 @@ base() noexcept
     return *this;
 }
     
+inline
 url_view const&
 url_view::
 base() const noexcept
@@ -28,6 +30,7 @@ base() const noexcept
 }
 
 // return size of table in bytes
+inline
 std::size_t
 url_view::
 table_bytes() const noexcept
@@ -41,6 +44,7 @@ table_bytes() const noexcept
 }
 
 // return length of [first, last)
+inline
 auto
 url_view::
 len(
@@ -54,6 +58,7 @@ len(
 }
 
 // change id to size n
+inline
 void
 url_view::
 set_size(
@@ -68,6 +73,7 @@ set_size(
 
 // trim id to size n,
 // moving excess into id+1
+inline
 void
 url_view::
 split(
@@ -80,6 +86,7 @@ split(
 }
 
 // add n to [first, last]
+inline
 void
 url_view::
 adjust(
@@ -93,6 +100,7 @@ adjust(
 }
 
 // set [first, last) offset
+inline
 void
 url_view::
 collapse(

--- a/include/boost/url/params.hpp
+++ b/include/boost/url/params.hpp
@@ -183,7 +183,6 @@ public:
         @param init Initializer list with query parameters
 
      */
-    inline
     params&
     operator=(std::initializer_list<value_type> init);
 
@@ -196,7 +195,6 @@ public:
         @param init Initializer list with query parameters
 
      */
-    inline
     void
     assign(std::initializer_list<
         value_type> init);
@@ -262,7 +260,6 @@ public:
         @param pos Position
 
      */
-    inline
     const_reference
     at(std::size_t pos) const;
 
@@ -294,7 +291,6 @@ public:
         @return Reference to first query parameter in the container
 
      */
-    inline
     const_reference
     front() const;
 
@@ -303,7 +299,6 @@ public:
         @return Reference to last query parameter in the container
 
      */
-    inline
     const_reference
     back() const;
 
@@ -318,7 +313,6 @@ public:
         @return Iterator to beginning of the container
 
      */
-    inline
     const_iterator
     begin() const noexcept;
 
@@ -327,7 +321,6 @@ public:
         @return Iterator to the end of the container
 
      */
-    inline
     iterator
     end() const noexcept;
 
@@ -342,7 +335,6 @@ public:
         @return True if container is empty
 
      */
-    inline
     bool
     empty() const noexcept;
 
@@ -351,7 +343,6 @@ public:
         @return Number of elements in the container
 
      */
-    inline
     std::size_t
     size() const noexcept;
 
@@ -367,7 +358,6 @@ public:
         `erase(begin(), end())`.
 
      */
-    inline
     void
     clear() noexcept;
 
@@ -382,7 +372,6 @@ public:
         @param v Element to be inserted
 
       */
-    inline
     iterator
     insert(
         iterator before,
@@ -400,7 +389,6 @@ public:
         @param init Elements to be inserted
 
      */
-    inline
     iterator
     insert(
         iterator before,
@@ -468,7 +456,6 @@ public:
         @param value New value for the position
 
      */
-    inline
     iterator
     replace(
         iterator pos,
@@ -514,7 +501,6 @@ public:
         @param init List of elements to replace the range
 
      */
-    inline
     iterator
     replace(
         iterator from,
@@ -560,7 +546,6 @@ public:
         @param value Value of the new element
 
      */
-    inline
     iterator
     emplace_at(
         iterator pos,
@@ -580,7 +565,6 @@ public:
         @param key The key of the new element
 
       */
-    inline
     iterator
     emplace_at(
         iterator pos,
@@ -597,7 +581,6 @@ public:
         @param value Value of the query param
 
       */
-    inline
     iterator
     emplace_before(
         iterator before,
@@ -613,7 +596,6 @@ public:
         @param key Key of the new query param
 
       */
-    inline
     iterator
     emplace_before(
         iterator before,
@@ -626,7 +608,6 @@ public:
         @param pos Position whose element should be erased
 
       */
-    inline
     iterator
     erase(iterator pos);
 
@@ -663,7 +644,6 @@ public:
         @param key String-like element key
 
       */
-    inline
     iterator
     emplace_back(
         string_view key);
@@ -677,7 +657,6 @@ public:
         @param value Element value
 
       */
-    inline
     iterator
     emplace_back(
         string_view key,
@@ -688,14 +667,12 @@ public:
         @param value Value to be inserted
 
       */
-    inline
     void
     push_back(
         value_type const& value);
 
     /** Remove element at the end of the container
       */
-    inline
     void
     pop_back() noexcept;
 
@@ -723,7 +700,6 @@ public:
         @param key Element key
 
       */
-    inline
     iterator
     find(string_view key) const noexcept;
 
@@ -753,7 +729,6 @@ public:
         @param key Element key
 
       */
-    inline
     bool
     contains(string_view key) const noexcept;
 

--- a/include/boost/url/params_encoded.hpp
+++ b/include/boost/url/params_encoded.hpp
@@ -46,7 +46,6 @@ class params_encoded
 
         @param u The url with the query params
      */
-    inline
     explicit
     params_encoded(
         url& u) noexcept;
@@ -103,7 +102,6 @@ public:
         @param init Initializer list with query parameters
 
       */
-    inline
     params_encoded&
     operator=(std::initializer_list<
         value_type> init);
@@ -119,7 +117,6 @@ public:
         @param init Initializer list with query parameters
 
     */
-    inline
     void
     assign(std::initializer_list<
         value_type> init);
@@ -188,7 +185,6 @@ public:
         @param pos Position
 
       */
-    inline
     value_type
     at(std::size_t pos) const;
 
@@ -220,7 +216,6 @@ public:
         @return Query params reference
 
       */
-    inline
     value_type
     front() const;
 
@@ -228,7 +223,6 @@ public:
 
         @return Query params reference
       */
-    inline
     value_type
     back() const;
 
@@ -242,7 +236,6 @@ public:
 
         @return Iterator to first element
       */
-    inline
     iterator
     begin() const noexcept;
 
@@ -251,7 +244,6 @@ public:
         @return Iterator to one past the last element
 
       */
-    inline
     iterator
     end() const noexcept;
 
@@ -265,7 +257,6 @@ public:
 
         @return True if container is empty
       */
-    inline
     bool
     empty() const noexcept;
 
@@ -274,7 +265,6 @@ public:
         @return The number of query parameters in the url
 
      */
-    inline
     std::size_t
     size() const noexcept;
 
@@ -290,7 +280,6 @@ public:
         `erase(begin(), end())`.
 
       */
-    inline
     void
     clear() noexcept;
 
@@ -308,7 +297,6 @@ public:
         @param v Element to be inserted
 
       */
-    inline
     iterator
     insert(
         iterator before,
@@ -323,7 +311,6 @@ public:
         @param init Elements to be inserted
 
       */
-    inline
     iterator
     insert(
         iterator before,
@@ -391,7 +378,6 @@ public:
         @param value New value for the position
 
      */
-    inline
     iterator
     replace(
         iterator pos,
@@ -437,7 +423,6 @@ public:
         @param init List of elements to replace the range
 
       */
-    inline
     iterator
     replace(
         iterator from,
@@ -485,7 +470,6 @@ public:
         @param value Value of the new element
 
       */
-    inline
     iterator
     emplace_at(
         iterator pos,
@@ -504,7 +488,6 @@ public:
         @param key The key of the new element
 
       */
-    inline
     iterator
     emplace_at(
         iterator pos,
@@ -521,7 +504,6 @@ public:
         @param value Value of the query param
 
       */
-    inline
     iterator
     emplace_before(
         iterator before,
@@ -537,7 +519,6 @@ public:
         @param key Key of the new query param
 
       */
-    inline
     iterator
     emplace_before(
         iterator before,
@@ -552,7 +533,6 @@ public:
         @param pos Position whose element should be erased
 
       */
-    inline
     iterator
     erase(iterator pos);
 
@@ -591,7 +571,6 @@ public:
         @param key Element key
 
       */
-    inline
     iterator
     emplace_back(
         string_view key);
@@ -605,7 +584,6 @@ public:
         @param value Element value
 
       */
-    inline
     iterator
     emplace_back(
         string_view key,
@@ -615,14 +593,12 @@ public:
 
         @param value Value to be inserted
       */
-    inline
     void
     push_back(
         value_type const& value);
 
     /** Remove element at the last position of the container
       */
-    inline
     void
     pop_back() noexcept;
 
@@ -650,7 +626,6 @@ public:
         @param key Element key
 
       */
-    inline
     iterator
     find(string_view key) const noexcept;
 
@@ -680,7 +655,6 @@ public:
         @param key Element key
 
       */
-    inline
     bool
     contains(string_view key) const noexcept;
 

--- a/include/boost/url/params_encoded_view.hpp
+++ b/include/boost/url/params_encoded_view.hpp
@@ -81,7 +81,6 @@ class params_encoded_view
     string_view s_;
     std::size_t n_ = 0;
 
-    inline
     params_encoded_view(
         string_view s,
         std::size_t n) noexcept;
@@ -214,13 +213,11 @@ public:
 
     /** Return true if the range contains no elements.
     */
-    inline
     bool
     empty() const noexcept;
 
     /** Return the number of elements in the range.
     */
-    inline
     std::size_t
     size() const noexcept;
 
@@ -261,7 +258,6 @@ public:
 
         @param key The encoded key.
     */
-    inline
     iterator
     find(string_view key) const noexcept;
 
@@ -304,7 +300,6 @@ public:
 
         @param key The encoded key.
     */
-    inline
     bool
     contains(string_view key) const noexcept;
 

--- a/include/boost/url/params_view.hpp
+++ b/include/boost/url/params_view.hpp
@@ -132,11 +132,9 @@ public:
     //
     //--------------------------------------------
 
-    inline
     bool
     empty() const noexcept;
 
-    inline
     std::size_t
     size() const noexcept;
 
@@ -150,7 +148,6 @@ public:
     std::size_t
     count(string_view key) const noexcept;
 
-    inline
     iterator
     find(string_view key) const noexcept;
 
@@ -162,7 +159,6 @@ public:
         iterator from,
         string_view key) const noexcept;
 
-    inline
     bool
     contains(string_view key) const noexcept;
 };

--- a/include/boost/url/segments.hpp
+++ b/include/boost/url/segments.hpp
@@ -122,7 +122,6 @@ public:
         Absolute paths always start with a
         forward slash ('/').
     */
-    inline
     bool
     is_absolute() const noexcept;
 
@@ -157,7 +156,6 @@ public:
 
         @param init An initializer list of strings.
     */
-    inline
     segments&
     operator=(std::initializer_list<string_view> init);
 
@@ -241,7 +239,6 @@ public:
         @param i The zero-based index of the
         element.
     */
-    inline
     const_string
     at(std::size_t i) const;
 
@@ -270,13 +267,11 @@ public:
 
     /** Return the first element
     */
-    inline
     const_string
     front() const;
 
     /** Return the last element
     */
-    inline
     const_string
     back() const;
 
@@ -288,13 +283,11 @@ public:
 
     /** Return an iterator to the beginning.
     */
-    inline
     iterator
     begin() const noexcept;
 
     /** Return an iterator to the end.
     */
-    inline
     iterator
     end() const noexcept;
 
@@ -310,7 +303,6 @@ public:
         no elements in the container. That is, if
         the underlying path is the empty string.
     */
-    inline
     bool
     empty() const noexcept;
 
@@ -323,7 +315,6 @@ public:
         @par Exception Safety
         Throws nothing.
     */
-    inline
     std::size_t
     size() const noexcept;
 
@@ -347,7 +338,6 @@ public:
         @par Exception Safety
         Throws nothing.
     */
-    inline
     void
     clear() noexcept;
 
@@ -422,7 +412,6 @@ public:
         @param init The initializer list containing
         unencoded segments to insert.
     */
-    inline
     iterator
     insert(
         iterator before,
@@ -519,13 +508,11 @@ public:
 
     //--------------------------------------------
 
-    inline
     iterator
     replace(
         iterator pos,
         string_view s);
 
-    inline
     iterator
     replace(
         iterator from,
@@ -586,7 +573,6 @@ public:
         @param pos An iterator to the
         element to erase.
     */
-    inline
     iterator
     erase(
         iterator pos) noexcept;
@@ -662,7 +648,6 @@ public:
 
         @throw std::invalid_argument invalid percent-encoding
     */
-    inline
     void
     push_back(
         string_view s);
@@ -693,7 +678,6 @@ public:
         @par Exception Safety
         Throws nothing.
     */
-    inline
     void
     pop_back() noexcept;
 };

--- a/include/boost/url/segments_encoded.hpp
+++ b/include/boost/url/segments_encoded.hpp
@@ -71,7 +71,6 @@ class segments_encoded
 
     friend class url;
 
-    inline
     explicit
     segments_encoded(
         url& u) noexcept;
@@ -122,7 +121,6 @@ public:
         Absolute paths always start with a
         forward slash ('/').
     */
-    inline
     bool
     is_absolute() const noexcept;
 
@@ -170,7 +168,6 @@ public:
 
         @throw std::invalid_argument invalid percent-encoding
     */
-    inline
     segments_encoded&
     operator=(std::initializer_list<string_view> init);
 
@@ -254,7 +251,6 @@ public:
         @param i The zero-based index of the
         element.
     */
-    inline
     string_view
     at(std::size_t i) const;
 
@@ -283,13 +279,11 @@ public:
 
     /** Return the first element
     */
-    inline
     string_view
     front() const noexcept;
 
     /** Return the last element
     */
-    inline
     const_reference
     back() const noexcept;
 
@@ -301,13 +295,11 @@ public:
 
     /** Return an iterator to the beginning
     */
-    inline
     iterator
     begin() const noexcept;
 
     /** Return an iterator to the end
     */
-    inline
     iterator
     end() const noexcept;
 
@@ -323,7 +315,6 @@ public:
         no elements in the container. That is, if
         the underlying path is the empty string.
     */
-    inline
     bool
     empty() const noexcept;
 
@@ -336,7 +327,6 @@ public:
         @par Exception Safety
         Throws nothing.
     */
-    inline
     std::size_t
     size() const noexcept;
 
@@ -360,7 +350,6 @@ public:
         @par Exception Safety
         Throws nothing.
     */
-    inline
     void
     clear() noexcept;
 
@@ -448,7 +437,6 @@ public:
 
         @throw std::invalid_argument invalid percent-encoding
     */
-    inline
     iterator
     insert(
         iterator before,
@@ -579,7 +567,6 @@ public:
         @param pos An iterator to the
         element to erase.
     */
-    inline
     iterator
     erase(
         iterator pos) noexcept;
@@ -628,13 +615,11 @@ public:
 
     //--------------------------------------------
 
-    inline
     iterator
     replace(
         iterator pos,
         string_view s);
 
-    inline
     iterator
     replace(
         iterator from,
@@ -688,7 +673,6 @@ public:
 
         @throw std::invalid_argument invalid percent-encoding
     */
-    inline
     void
     push_back(
         string_view s);
@@ -719,7 +703,6 @@ public:
         @par Exception Safety
         Throws nothing.
     */
-    inline
     void
     pop_back() noexcept;
 };

--- a/include/boost/url/segments_encoded_view.hpp
+++ b/include/boost/url/segments_encoded_view.hpp
@@ -137,7 +137,6 @@ public:
         A default-constructed instance will be
         an empty range.
     */
-    inline
     segments_encoded_view() noexcept;
 
     /** Assignment
@@ -194,7 +193,6 @@ public:
         Absolute paths always start with a
         forward slash ('/').
     */
-    inline
     bool
     is_absolute() const noexcept;
 
@@ -206,13 +204,11 @@ public:
 
     /** Return the first element.
     */
-    inline
     string_view
     front() const noexcept;
 
     /** Return the last element.
     */
-    inline
     string_view
     back() const noexcept;
 
@@ -242,13 +238,11 @@ public:
 
     /** Return true if the range contains no elements
     */
-    inline
     bool
     empty() const noexcept;
 
     /** Return the number of elements in the range
     */
-    inline
     std::size_t
     size() const noexcept;
 

--- a/include/boost/url/segments_view.hpp
+++ b/include/boost/url/segments_view.hpp
@@ -83,7 +83,6 @@ public:
         Default constructed views represent an
         empty path.
     */
-    inline
     segments_view() noexcept;
 
     /** Assignment
@@ -100,7 +99,6 @@ public:
         Absolute paths always start with a
         forward slash ('/').
     */
-    inline
     bool
     is_absolute() const noexcept;
 
@@ -112,13 +110,11 @@ public:
 
     /** Return the first element.
     */
-    inline
     const_string
     front() const noexcept;
 
     /** Return the last element.
     */
-    inline
     const_string
     back() const noexcept;
 
@@ -148,13 +144,11 @@ public:
 
     /** Return true if the range contains no elements
     */
-    inline
     bool
     empty() const noexcept;
 
     /** Return the number of elements in the range
     */
-    inline
     std::size_t
     size() const noexcept;
 

--- a/include/boost/url/url.hpp
+++ b/include/boost/url/url.hpp
@@ -1446,7 +1446,6 @@ public:
     //--------------------------------------------
 
     friend
-    inline
     void
     resolve(
         url_view const& base,

--- a/include/boost/url/url_view.hpp
+++ b/include/boost/url/url_view.hpp
@@ -118,15 +118,15 @@ protected:
     friend class static_url_base;
     struct shared_impl;
 
-    inline url_view& base() noexcept;
-    inline url_view const& base() const noexcept;
-    inline std::size_t table_bytes() const noexcept;
-    inline pos_t len(int first, int last) const noexcept;
-    inline void set_size(int id, pos_t n) noexcept;
-    inline void split(int id, std::size_t n) noexcept;
-    inline void adjust(int first, int last,
+    url_view& base() noexcept;
+    url_view const& base() const noexcept;
+    std::size_t table_bytes() const noexcept;
+    pos_t len(int first, int last) const noexcept;
+    void set_size(int id, pos_t n) noexcept;
+    void split(int id, std::size_t n) noexcept;
+    void adjust(int first, int last,
         std::size_t n) noexcept;
-    inline void collapse(int first, int last,
+    void collapse(int first, int last,
         std::size_t n) noexcept;
 
     BOOST_URL_DECL


### PR DESCRIPTION
fix #109

This fixes all declarations and definitions at once.