### PR TITLE
rename collect to persist 

### DIFF
--- a/doc/qbk/3.0.parsing.qbk
+++ b/doc/qbk/3.0.parsing.qbk
@@ -274,10 +274,10 @@ extends until the view is destroyed.
 [heading Copying]
 
 The function
-[link url.ref.boost__urls__url_view.collect `url_view::collect`]
+[link url.ref.boost__urls__url_view.persist `url_view::persist`]
 may be used to create a copy of the underlying character buffer and attach
 ownership of the buffer to a newly returned view, which is wrapped in a
-shared pointer. The following code calls `collect` to create a read-only
+shared pointer. The following code calls `persist` to create a read-only
 copy:
 
 [c++]

--- a/include/boost/url/authority_view.hpp
+++ b/include/boost/url/authority_view.hpp
@@ -378,7 +378,7 @@ public:
 
             assert( a.data() == s.data() );                     // same buffer
 
-            sp = a.collect();
+            sp = a.persist();
 
             assert( sp->data() != a.data() );                   // different buffer
             assert( sp->encoded_authority() == s);              // same contents
@@ -392,7 +392,7 @@ public:
     BOOST_URL_DECL
     std::shared_ptr<
         authority_view const>
-    collect() const;
+    persist() const;
 
     /** Return the complete authority
 

--- a/include/boost/url/impl/authority_view.ipp
+++ b/include/boost/url/impl/authority_view.ipp
@@ -83,7 +83,7 @@ operator=(
 std::shared_ptr<
     authority_view const>
 authority_view::
-collect() const
+persist() const
 {
     using T = shared_impl;
     using Alloc = std::allocator<char>;

--- a/include/boost/url/impl/url_view.ipp
+++ b/include/boost/url/impl/url_view.ipp
@@ -100,8 +100,7 @@ url_view(string_view s)
 
 std::shared_ptr<
     url_view const>
-url_view::
-collect() const
+url_view::persist() const
 {
     using T = shared_impl;
     using Alloc = std::allocator<char>;

--- a/include/boost/url/url_view.hpp
+++ b/include/boost/url/url_view.hpp
@@ -392,7 +392,19 @@ public:
             data(), size());
     }
 
-    /** Return a read-only copy of the URL, with shared lifetime.
+    /** Return a shared persistent copy of the URL view
+
+        This function returns a read-only copy of
+        the URL view, with shared lifetime. The
+        new URL view owns (persists) the underlying
+        string.
+
+        The main benefit of this function over
+        `std::make_shared` or `std::allocate_shared`
+        is using a single allocation for both the
+        new view and the character buffer. Thus,
+        it requires access to the underlying object
+        representation to achieve that.
 
         This function makes a copy of the storage
         pointed to by this, and attaches it to a
@@ -412,7 +424,7 @@ public:
 
             assert( u.data() == s.data() );         // same buffer
 
-            sp = u.collect();
+            sp = u.persist();
 
             assert( sp->data() != s.data() );       // different buffer
             assert( sp->string() == s);        // same contents
@@ -425,8 +437,7 @@ public:
     */
     BOOST_URL_DECL
     std::shared_ptr<
-        url_view const>
-    collect() const;
+        url_view const> persist() const;
 
     //--------------------------------------------
     //

--- a/test/unit/authority_view.cpp
+++ b/test/unit/authority_view.cpp
@@ -107,7 +107,7 @@ public:
             BOOST_TEST_EQ(a.encoded_authority().data(), s.data());
         }
 
-        // collect()
+        // persist()
         {
         std::shared_ptr<authority_view const> sp;
         {
@@ -116,7 +116,7 @@ public:
 
             assert( a.data() == s.data() );                     // same buffer
 
-            sp = a.collect();
+            sp = a.persist();
 
             assert( sp->data() != s.data() );                   // different buffer
             assert( sp->encoded_authority() == s);              // same contents

--- a/test/unit/snippets.cpp
+++ b/test/unit/snippets.cpp
@@ -209,7 +209,7 @@ parsing_urls()
         urls::url_view u = urls::parse_relative_ref( s ).value();
 
         // create a copy with ownership and string lifetime extension
-        sp = u.collect();
+        sp = u.persist();
 
         // At this point the string goes out of scope
     }

--- a/test/unit/url_view.cpp
+++ b/test/unit/url_view.cpp
@@ -113,7 +113,7 @@ public:
             BOOST_TEST_EQ(u.string().data(), s.data());
         }
 
-        // collect()
+        // persist()
         {
         std::shared_ptr<url_view const> sp;
         {
@@ -122,7 +122,7 @@ public:
 
             assert( u.data() == s.data() );         // same buffer
 
-            sp = u.collect();
+            sp = u.persist();
 
             assert( sp->data() != s.data() );       // different buffer
             assert( sp->string() == s);        // same contents


### PR DESCRIPTION
fix #208

BREAKING CHANGE: The function url_view::collect is now called url_view::persist