### PR TITLE
fix: Use Boost::boost in target_link_libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,13 +76,8 @@ function(boost_url_setup_properties target)
     else()
         target_link_libraries(${target}
             PUBLIC
-                Boost::align
-                Boost::assert
-                Boost::config
-                Boost::mp11
+                Boost::boost
                 Boost::system
-                Boost::throw_exception
-                Boost::type_traits
         )
     endif()
 


### PR DESCRIPTION
When using the library in a CMake-based project with FetchContent_Declare() CMake cannot find Boost::align, Boost::asert, etc. because these are header-only libraries. Only Boost::system is a library that can be linked. 
To specify Boost::boost fixed this problem. Then all Boost headers are available.