### PR TITLE
update pct encoding API

### DIFF
--- a/include/boost/url/authority_view.hpp
+++ b/include/boost/url/authority_view.hpp
@@ -538,8 +538,17 @@ public:
     {
         pct_decode_opts opt;
         opt.plus_to_space = false;
-        return pct_decode_unchecked(
-            encoded_userinfo(), opt, a);
+        string_view s = encoded_userinfo();
+        std::size_t n =
+            pct_decode_bytes_unchecked(s);
+        return const_string(
+            n, a,
+            [&s, &opt](
+                std::size_t n, char* dest)
+            {
+                pct_decode_unchecked(
+                    dest, dest + n, s, opt);
+            });
     }
 
     //--------------------------------------------
@@ -632,8 +641,17 @@ public:
     {
         pct_decode_opts opt;
         opt.plus_to_space = false;
-        return pct_decode_unchecked(
-            encoded_user(), opt, a);
+        string_view s = encoded_user();
+        std::size_t n =
+            pct_decode_bytes_unchecked(s);
+        return const_string(
+            n, a,
+            [&s, &opt](
+                std::size_t n, char* dest)
+            {
+            pct_decode_unchecked(
+                dest, dest + n, s, opt);
+            });
     }
 
     /** Return true if this contains a password
@@ -748,8 +766,17 @@ public:
     {
         pct_decode_opts opt;
         opt.plus_to_space = false;
-        return pct_decode_unchecked(
-            encoded_password(), opt, a);
+        string_view s = encoded_password();
+        std::size_t n =
+            pct_decode_bytes_unchecked(s);
+        return const_string(
+            n, a,
+            [&s, &opt](
+                std::size_t n, char* dest)
+            {
+            pct_decode_unchecked(
+                dest, dest + n, s, opt);
+            });
     }
 
     //--------------------------------------------

--- a/include/boost/url/detail/impl/any_path_iter.ipp
+++ b/include/boost/url/detail/impl/any_path_iter.ipp
@@ -76,7 +76,7 @@ measure(
         return false;
     string_view s(p_, n_);
     urls::validate_pct_encoding(
-        s, ec, {}, pchars);
+        s, ec, pchars, {});
     if(ec.failed())
         return false;
     n += s.size();
@@ -158,7 +158,7 @@ measure(
         return false;
     string_view s(p_, n_);
     n += urls::pct_encode_bytes(
-        s, {}, pchars);
+        s, pchars);
     increment();
     return true;
 }
@@ -173,7 +173,6 @@ copy(
     dest += pct_encode(
         dest, end,
         string_view(p_, n_),
-        {},
         pchars);
     increment();
 }
@@ -188,7 +187,7 @@ measure_impl(
     error_code& ec) noexcept
 {
     urls::validate_pct_encoding(
-        s, ec, {}, pchars);
+        s, ec, pchars, {});
     if(ec.failed())
         return false;
     n += s.size();
@@ -222,8 +221,7 @@ measure_impl(
     string_view s,
     std::size_t& n) noexcept
 {
-    n += pct_encode_bytes(
-        s, {}, pchars);
+    n += pct_encode_bytes(s, pchars);
 }
 
 void
@@ -234,7 +232,7 @@ copy_impl(
     char const* end) noexcept
 {
     dest += pct_encode(
-        dest, end, s, {}, pchars);
+        dest, end, s, pchars);
 }
 
 } // detail

--- a/include/boost/url/detail/impl/any_query_iter.ipp
+++ b/include/boost/url/detail/impl/any_query_iter.ipp
@@ -73,7 +73,7 @@ measure(
         return false;
     string_view s(p_, n_);
     urls::validate_pct_encoding(
-        s, ec, {}, query_chars);
+        s, ec, query_chars, {});
     if(ec.failed())
         return false;
     n += s.size();
@@ -152,7 +152,7 @@ measure(
         return false;
     string_view s(p_, n_);
     n += urls::pct_encode_bytes(
-        s, {}, query_chars);
+        s, query_chars);
     increment();
     return true;
 }
@@ -167,7 +167,6 @@ copy(
     dest += pct_encode(
         dest, end,
         string_view(p_, n_),
-        {},
         query_chars);
     increment();
 }
@@ -185,14 +184,14 @@ measure_impl(
     pct_decode_opts opt;
     opt.plus_to_space = true;
     validate_pct_encoding(
-        key, ec, opt, query_chars);
+        key, ec, query_chars, opt);
     if(ec.failed())
         return false;
     n += key.size();
     if(value)
     {
         validate_pct_encoding(
-            *value, ec, opt, query_chars);
+            *value, ec, query_chars, opt);
         if(ec.failed())
             return false;
         n += 1 + value->size();
@@ -246,13 +245,11 @@ measure_impl(
     string_view const* value,
     std::size_t& n) noexcept
 {
-    n += pct_encode_bytes(
-        key, {}, query_chars);
+    n += pct_encode_bytes(key, query_chars);
     if(value)
     {
         ++n; // '='
-        n += pct_encode_bytes(
-            *value, {}, query_chars);
+        n += pct_encode_bytes(*value, query_chars);
     }
 }
 
@@ -265,12 +262,12 @@ copy_impl(
     char const* end) noexcept
 {
     dest += pct_encode(
-        dest, end, key, {}, query_chars);
+        dest, end, key, query_chars);
     if(value)
     {
         *dest++ = '=';
         dest += pct_encode(
-            dest, end, *value, {}, query_chars);
+            dest, end, *value, query_chars);
     }
 }
 
@@ -287,8 +284,7 @@ measure_impl(
     if(value)
     {
         ++n; // '='
-        n += pct_encode_bytes(
-            *value, {}, query_chars);
+        n += pct_encode_bytes(*value, query_chars);
     }
 }
 
@@ -310,7 +306,7 @@ copy_impl(
     {
         *dest++ = '=';
         dest += pct_encode(
-            dest, end, *value, {}, query_chars);
+            dest, end, *value, query_chars);
     }
 }
 

--- a/include/boost/url/impl/pct_encoded_view.ipp
+++ b/include/boost/url/impl/pct_encoded_view.ipp
@@ -47,9 +47,7 @@ pct_encoded_view(
 {
     error_code ec;
     opt.non_normal_is_error = false;
-    dn_ = validate_pct_encoding(
-        str, ec, opt,
-        [](unsigned char c) { return c != '%'; });
+    dn_ = validate_pct_encoding(str, ec, opt);
     if (ec.failed())
         detail::throw_invalid_argument(
             BOOST_CURRENT_LOCATION);

--- a/include/boost/url/impl/pct_encoding.ipp
+++ b/include/boost/url/impl/pct_encoding.ipp
@@ -133,6 +133,142 @@ pct_decode_unchecked(
     return dest - dest0;
 }
 
+namespace detail
+{
+std::size_t
+validate_pct_encoding(
+    string_view s,
+    error_code& ec,
+    std::true_type) noexcept
+{
+    const auto is_safe = [](char c)
+    {
+        return c != '%';
+    };
+
+    std::size_t pcts = 0;
+    char const* it = s.data();
+    char const* end = it + s.size();
+    it = grammar::find_if_not(it, end, is_safe);
+    while (it != end)
+    {
+        if (end - it < 2)
+        {
+            // missing HEXDIG
+            ec = BOOST_URL_ERR(
+                error::missing_pct_hexdig);
+            return it - s.data() - pcts * 2;
+        }
+        if (!grammar::hexdig_chars(it[1]) ||
+            !grammar::hexdig_chars(it[2]))
+        {
+            // expected HEXDIG
+            ec = BOOST_URL_ERR(
+                error::bad_pct_hexdig);
+            return it - s.data() - pcts * 2;
+        }
+        it += 3;
+        ++pcts;
+        it = grammar::find_if_not(it, end, is_safe);
+    }
+    ec = {};
+    return s.size() - pcts * 2;
+}
+
+std::size_t
+validate_pct_encoding(
+    string_view s,
+    error_code& ec,
+    std::false_type) noexcept
+{
+    const auto is_safe = [](char c)
+    {
+        return c != '%' && c != '\0';
+    };
+
+    std::size_t pcts = 0;
+    char const* it = s.data();
+    char const* end = it + s.size();
+    it = grammar::find_if_not(it, end, is_safe);
+    while (it != end)
+    {
+        if (*it == '\0')
+        {
+            // null in input
+            ec = BOOST_URL_ERR(
+                error::illegal_null);
+            return it - s.data() - pcts * 2;
+        }
+        if (end - it < 2)
+        {
+            // missing HEXDIG
+            ec = BOOST_URL_ERR(
+                error::missing_pct_hexdig);
+            return it - s.data() - pcts * 2;
+        }
+        if (!grammar::hexdig_chars(it[1]) ||
+            !grammar::hexdig_chars(it[2]))
+        {
+            // expected HEXDIG
+            ec = BOOST_URL_ERR(
+                error::bad_pct_hexdig);
+            return it - s.data() - pcts * 2;
+        }
+        if (it[1] == '0' &&
+            it[2] == '0')
+        {
+            // null in input
+            ec = BOOST_URL_ERR(
+                error::illegal_null);
+            return it - s.data() - pcts * 2;
+        }
+        it += 3;
+        ++pcts;
+        it = grammar::find_if_not(it, end, is_safe);
+    }
+    ec = {};
+    return s.size() - pcts * 2;
+}
+}
+
+std::size_t
+validate_pct_encoding(
+    string_view s,
+    error_code& ec,
+    pct_decode_opts const& opt) noexcept
+{
+    if (opt.allow_null)
+        return detail::validate_pct_encoding(
+            s, ec, std::true_type{});
+    else
+       return detail::validate_pct_encoding(
+            s, ec, std::false_type{});
+}
+
+std::size_t
+pct_decode(
+    char* dest,
+    char const* end,
+    string_view s,
+    error_code& ec,
+    pct_decode_opts const& opt) noexcept
+{
+    auto const n =
+        validate_pct_encoding(s, ec, opt);
+    if(ec.failed())
+        return 0;
+    auto const n1 =
+        pct_decode_unchecked(
+            dest, end, s, opt);
+    if(n1 < n)
+    {
+        ec = error::no_space;
+        return n1;
+    }
+    return n1;
+}
+
+
 } // urls
 } // boost
 

--- a/include/boost/url/impl/url.ipp
+++ b/include/boost/url/impl/url.ipp
@@ -407,10 +407,10 @@ set_user(string_view s)
     s = buf.maybe_copy(s);
     check_invariants();
     auto const n = pct_encode_bytes(
-        s, {}, detail::user_chars);
+        s, detail::user_chars);
     auto dest = set_user_impl(n);
     pct_encode(dest, get(id_pass).data(),
-        s, {}, detail::user_chars);
+        s, detail::user_chars);
     decoded_[id_user] = s.size();
     check_invariants();
     return *this;
@@ -427,7 +427,7 @@ set_encoded_user(
     check_invariants();
     error_code ec;
     auto const n =
-        validate_pct_encoding(s, ec, {}, detail::user_chars);
+        validate_pct_encoding(s, ec, detail::user_chars, {});
     if(ec.failed())
         detail::throw_invalid_argument(
             BOOST_CURRENT_LOCATION);
@@ -501,13 +501,12 @@ set_password(string_view s)
     s = buf.maybe_copy(s);
     check_invariants();
     auto const n = pct_encode_bytes(
-        s, {}, detail::password_chars);
+        s, detail::password_chars);
     auto dest = set_password_impl(n);
     pct_encode(
         dest,
         get(id_host).data() - 1,
         s,
-        {},
         detail::password_chars);
     decoded_[id_pass] = s.size();
     check_invariants();
@@ -525,7 +524,7 @@ set_encoded_password(
     check_invariants();
     error_code ec;
     auto const n =
-        validate_pct_encoding(s, ec, {}, detail::password_chars);
+        validate_pct_encoding(s, ec, detail::password_chars, {});
     if(ec.failed())
         detail::throw_invalid_argument(
             BOOST_CURRENT_LOCATION);
@@ -590,13 +589,12 @@ set_userinfo(
     s = buf.maybe_copy(s);
     check_invariants();
     auto const n = pct_encode_bytes(
-        s, {}, detail::userinfo_chars);
+        s, detail::userinfo_chars);
     auto dest = set_userinfo_impl(n);
     pct_encode(
         dest,
         get(id_host).data() - 1,
         s,
-        {},
         detail::userinfo_chars);
     decoded_[id_user] = s.size();
     check_invariants();
@@ -724,13 +722,12 @@ set_host(
     }
     check_invariants();
     auto const n = pct_encode_bytes(
-        s, {}, detail::host_chars);
+        s, detail::host_chars);
     auto dest = set_host_impl(n);
     pct_encode(
         dest,
         get(id_path).data(),
         s,
-        {},
         detail::host_chars);
     decoded_[id_host] = s.size();
     host_type_ =
@@ -1799,13 +1796,12 @@ set_fragment(
     s = buf.maybe_copy(s);
     check_invariants();
     auto const n = pct_encode_bytes(
-        s, {}, fragment_chars);
+        s, fragment_chars);
     auto dest = set_fragment_impl(n);
     pct_encode(
         dest,
         get(id_end).data(),
         s,
-        {},
         fragment_chars);
     decoded_[id_frag] = s.size();
     check_invariants();

--- a/include/boost/url/url_view.hpp
+++ b/include/boost/url/url_view.hpp
@@ -778,8 +778,17 @@ public:
     {
         pct_decode_opts opt;
         opt.plus_to_space = false;
-        return pct_decode_unchecked(
-            encoded_userinfo(), opt, a);
+        string_view s = encoded_userinfo();
+        std::size_t n =
+            pct_decode_bytes_unchecked(s);
+        return const_string(
+            n, a,
+            [&s, &opt](
+                std::size_t n, char* dest)
+            {
+            pct_decode_unchecked(
+                dest, dest + n, s, opt);
+            });
     }
 
     //--------------------------------------------
@@ -870,8 +879,17 @@ public:
     {
         pct_decode_opts opt;
         opt.plus_to_space = false;
-        return pct_decode_unchecked(
-            encoded_user(), opt, a);
+        string_view s = encoded_user();
+        std::size_t n =
+            pct_decode_bytes_unchecked(s);
+        return const_string(
+            n, a,
+            [&s, &opt](
+                std::size_t n, char* dest)
+            {
+            pct_decode_unchecked(
+                dest, dest + n, s, opt);
+            });
     }
 
     /** Return true if this contains a password
@@ -986,8 +1004,17 @@ public:
     {
         pct_decode_opts opt;
         opt.plus_to_space = false;
-        return pct_decode_unchecked(
-            encoded_password(), opt, a);
+        string_view s = encoded_password();
+        std::size_t n =
+            pct_decode_bytes_unchecked(s);
+        return const_string(
+            n, a,
+            [&s, &opt](
+                std::size_t n, char* dest)
+            {
+            pct_decode_unchecked(
+                dest, dest + n, s, opt);
+            });
     }
 
     //--------------------------------------------
@@ -1586,8 +1613,17 @@ public:
     {
         pct_decode_opts opt;
         opt.plus_to_space = true;
-        return pct_decode_unchecked(
-            encoded_query(), opt, a);
+        string_view s = encoded_query();
+        std::size_t n =
+            pct_decode_bytes_unchecked(s);
+        return const_string(
+            n, a,
+            [&s, &opt](
+                std::size_t n, char* dest)
+            {
+            pct_decode_unchecked(
+                dest, dest + n, s, opt);
+            });
     }
 
     /** Return the query parameters


### PR DESCRIPTION
fix #230

This PR fixes the issue with the default parameters for pct encoding algorithms and updates the API according to the other recommendations in #230 

It would be good to have a good look at this because this has an impact at many other points of the library.

I'm still not sure what to do about the recommendation "add `pct_encode_append_to` and `pct_encode_assign_to`" because the functions `append` and `assign` depend on iterators which don't exist in that context:

- If the intention is to reuse the MutableString concept, the first alternative would be to create a whole new view class representing the opposite of `pct_encoded_view` (received decoded strings as input and outputing encoded strings) so we have iterators to provide `append` and `assign`. 
- If the intention is really to create a new concept, the second alternative is to create a new concept including MutableString _and_ `resize` in the recycled class. 
- The third alternative is, of course, only accepting `basic_string`. The we know we have `resize`, `assign` and `append`.