### PR TITLE
Refactor range

### DIFF
--- a/doc/qbk/quickref.xml
+++ b/doc/qbk/quickref.xml
@@ -192,7 +192,6 @@
           <member><link linkend="url.ref.boost__urls__grammar__not_empty_rule_t">not_empty_rule_t</link></member>
           <member><link linkend="url.ref.boost__urls__grammar__optional_rule_t">optional_rule_t</link></member>
           <member><link linkend="url.ref.boost__urls__grammar__range">range</link></member>
-          <member><link linkend="url.ref.boost__urls__grammar__range_fn">range_fn</link></member>
           <member><link linkend="url.ref.boost__urls__grammar__sequence_rule_t">sequence_rule_t</link></member>
           <member><link linkend="url.ref.boost__urls__grammar__token_rule_t">token_rule_t</link></member>
           <member><link linkend="url.ref.boost__urls__grammar__unsigned_dec_rule">unsigned_dec_rule</link></member>

--- a/include/boost/url/detail/impl/segments_encoded_iterator_impl.ipp
+++ b/include/boost/url/detail/impl/segments_encoded_iterator_impl.ipp
@@ -12,6 +12,7 @@
 #define BOOST_URL_DETAIL_IMPL_SEGMENTS_ENCODED_ITERATOR_IMPL_IPP
 
 #include <boost/url/detail/segments_encoded_iterator_impl.hpp>
+#include <boost/url/rfc/detail/path_increment.hpp>
 #include <boost/assert.hpp>
 
 namespace boost {
@@ -69,9 +70,9 @@ increment() noexcept
     ++i_;
     pos_ = next_;
     // "/" segment
-    auto rv =
-        path_rootless_rule{}.increment(
-            next_, end_);
+    auto rv = grammar::parse(
+        next_, end_,
+            detail::path_increment);
     if(rv == grammar::error::end)
     {
         next_ = nullptr;
@@ -100,8 +101,9 @@ decrement() noexcept
             continue;
         // "/" segment
         next_ = pos_;
-        auto rv = path_rootless_rule{}.increment(
-            next_, end_);
+        auto rv = grammar::parse(
+            next_, end_,
+            detail::path_increment);
         s_ = rv->encoded();
         return;
     }
@@ -109,15 +111,17 @@ decrement() noexcept
     if(*next_ == '/')
     {
         // "/" segment
-        auto rv = path_rootless_rule{}.increment(
-            next_, end_);
+        auto rv = grammar::parse(
+            next_, end_,
+            detail::path_increment);
         s_ = rv->encoded();
     }
     else
     {
         // segment-nz
-        auto rv = path_rootless_rule{}.begin(
-            next_, end_);
+        auto rv = grammar::parse(
+            next_, end_,
+                detail::path_increment);
         s_ = rv->encoded();
     }
 }

--- a/include/boost/url/detail/impl/segments_iterator_impl.ipp
+++ b/include/boost/url/detail/impl/segments_iterator_impl.ipp
@@ -74,8 +74,9 @@ increment() noexcept
     ++i_;
     pos_ = next_;
     // "/" segment
-    auto rv = path_rootless_rule{}.increment(
-        next_, end_);
+    auto rv = grammar::parse(
+        next_, end_,
+            detail::path_increment);
     if(rv == grammar::error::end)
     {
         next_ = nullptr;
@@ -105,22 +106,25 @@ decrement() noexcept
             continue;
         // "/" segment
         next_ = pos_;
-        t_ = path_rootless_rule{}.increment(
-            next_, end_).value();
+        t_ = grammar::parse(
+            next_, end_,
+            detail::path_increment).value();
         return;
     }
     next_ = pos_;
     if(*next_ == '/')
     {
         // "/" segment
-        t_ = path_rootless_rule{}.increment(
-            next_, end_).value();
+        t_ = grammar::parse(
+            next_, end_,
+            detail::path_increment).value();
     }
     else
     {
         // segment-nz
-        t_ = path_rootless_rule{}.begin(
-            next_, end_).value();
+        t_ = grammar::parse(
+            next_, end_,
+            detail::path_increment).value();
     }
 }
 

--- a/include/boost/url/rfc/detail/path_increment.hpp
+++ b/include/boost/url/rfc/detail/path_increment.hpp
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2016-2019 Vinnie Falco (vinnie dot falco at gmail dot com)
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// Official repository: https://github.com/CPPAlliance/url
+//
+
+#ifndef BOOST_URL_RFC_DETAIL_PATH_INCREMENT_IPP
+#define BOOST_URL_RFC_DETAIL_PATH_INCREMENT_IPP
+
+#include <boost/url/pct_encoded_view.hpp>
+#include <boost/url/rfc/detail/segment_rule.hpp>
+#include <boost/url/grammar/char_rule.hpp>
+#include <boost/url/grammar/parse.hpp>
+#include <boost/url/grammar/sequence_rule.hpp>
+#include <utility>
+
+namespace boost {
+namespace urls {
+namespace detail {
+
+struct path_increment_t
+{
+    using value_type = pct_encoded_view;
+
+    result<value_type>
+    parse(
+        char const *&it,
+        char const* end) const noexcept
+    {
+        auto it0 = it;
+        auto rv = grammar::parse(
+            it, end,
+            grammar::sequence_rule(
+                grammar::char_rule('/'),
+                segment_rule));
+        if(rv.has_value())
+            return std::get<1>(*rv);
+        it = it0;
+        return BOOST_URL_ERR(
+            grammar::error::end);
+    }
+};
+
+constexpr path_increment_t path_increment{};
+
+} // detail
+} // urls
+} // boost
+
+#endif

--- a/include/boost/url/rfc/impl/query_rule.ipp
+++ b/include/boost/url/rfc/impl/query_rule.ipp
@@ -21,6 +21,8 @@
 namespace boost {
 namespace urls {
 
+namespace detail {
+
 static
 constexpr
 auto
@@ -35,6 +37,8 @@ value_chars = pchars
     + '/' + '?'
     - '&';
 
+} // detail
+
 auto
 query_rule_t::
 parse(
@@ -43,98 +47,92 @@ parse(
         ) const noexcept ->
     result<value_type>
 {
+    struct query_param_rule_t
+    {
+        using value_type = query_param_view;
+
+        result<value_type>
+        parse(
+            char const*& it,
+            char const* end) const noexcept
+        {
+            query_param_view t;
+
+            // VFALCO we don't return error::end
+            // here, because the empty string still
+            // counts as a 1-element range with
+            // key="" and value=(none)
+
+            // key
+            {
+                auto rv = grammar::parse(it, end,
+                    pct_encoded_rule(detail::key_chars));
+                if(! rv)
+                    return rv.error();    
+                t.key = *rv;
+            }
+
+            // "="
+            {
+                auto rv = grammar::parse(
+                    it, end,
+                    grammar::char_rule('='));
+                t.has_value = rv.has_value();
+                if(! t.has_value)
+                {
+                    // key with no value
+                    return t;
+                }
+            }
+
+            // value
+            {
+                auto rv = grammar::parse(it, end,
+                    pct_encoded_rule(detail::value_chars));
+                if(! rv)
+                    return rv.error();
+                t.value = *rv;
+            }
+
+            return t;
+        }
+    };
+
+    struct increment
+    {
+        using value_type = query_param_view;
+
+        result<value_type>
+        parse(
+            char const*& it,
+            char const* end) const noexcept
+        {
+            // "&"
+            {
+                auto rv = grammar::parse(
+                    it, end,
+                    grammar::char_rule('&'));
+                if(! rv)
+                {
+                    // end of list
+                    return grammar::error::end;
+                }
+            }
+
+            return grammar::parse(it, end,
+                query_param_rule_t{});
+        }
+    };
+
     auto rv = grammar::parse_range(
-        it, end, *this,
-        &query_rule_t::begin,
-        &query_rule_t::increment);
+        it, end,
+        query_param_rule_t{},
+        increment{});
     if(! rv)
         return rv.error();
     return value_type(
         rv->string(),
         rv->size());
-}
-
-auto
-query_rule_t::
-begin(
-    char const*& it,
-    char const* const end
-        ) const noexcept ->
-    result<query_param_view>
-{
-    // VFALCO we don't return error::end
-    // here, because the empty string still
-    // counts as a 1-element range with
-    // key="" and value=(none)
-
-    return parse_query_param(it, end);
-}
-
-auto
-query_rule_t::
-increment(
-    char const*& it,
-    char const* const end
-        ) const noexcept ->
-    result<query_param_view>
-{
-    // "&"
-    {
-        auto rv = grammar::parse(
-            it, end,
-            grammar::char_rule('&'));
-        if(! rv)
-        {
-            // end of list
-            return grammar::error::end;
-        }
-    }
-
-    return parse_query_param(it, end);
-}
-
-auto
-query_rule_t::
-parse_query_param(
-    char const*& it,
-    char const* end
-        ) const noexcept ->
-    result<query_param_view>
-{
-    query_param_view t;
-
-    // key
-    {
-        auto rv = grammar::parse(it, end,
-            pct_encoded_rule(key_chars));
-        if(! rv)
-            return rv.error();    
-        t.key = *rv;
-    }
-
-    // "="
-    {
-        auto rv = grammar::parse(
-            it, end,
-            grammar::char_rule('='));
-        t.has_value = rv.has_value();
-        if(! t.has_value)
-        {
-            // key with no value
-            return t;
-        }
-    }
-
-    // value
-    {
-        auto rv = grammar::parse(it, end,
-            pct_encoded_rule(value_chars));
-        if(! rv)
-            return rv.error();
-        t.value = *rv;
-    }
-
-    return t;
 }
 
 } // urls

--- a/include/boost/url/rfc/paths_rule.hpp
+++ b/include/boost/url/rfc/paths_rule.hpp
@@ -60,21 +60,6 @@ struct path_abempty_rule
         char const*& it,
         char const* end
             ) const noexcept;
-
-private:
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    begin(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    increment(
-        char const*& it,
-        char const* end
-            ) const noexcept;
 };
 #endif
 
@@ -106,21 +91,6 @@ struct path_absolute_rule
         char const*& it,
         char const* end
             ) const noexcept;
-
-private:
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    begin(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    increment(
-        char const*& it,
-        char const* end
-            ) const noexcept;
 };
 #endif
 
@@ -149,21 +119,6 @@ struct path_noscheme_rule
     BOOST_URL_DECL
     result<value_type>
     parse(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-
-private:
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    begin(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    increment(
         char const*& it,
         char const* end
             ) const noexcept;
@@ -204,26 +159,6 @@ struct path_rootless_rule
         char const*& it,
         char const* end
             ) const noexcept;
-
-#ifndef BOOST_URL_DOCS
-//private:
-    //friend struct detail::segments_iterator_impl;
-    //friend struct detail::segments_encoded_iterator_impl;
-
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    begin(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-
-    BOOST_URL_DECL
-    result<pct_encoded_view>
-    increment(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-#endif
 };
 #endif
 

--- a/include/boost/url/rfc/query_rule.hpp
+++ b/include/boost/url/rfc/query_rule.hpp
@@ -51,27 +51,6 @@ struct query_rule_t
         char const*& it,
         char const* end
             ) const noexcept;
-
-private:
-    BOOST_URL_DECL
-    result<query_param_view>
-    begin(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-
-    BOOST_URL_DECL
-    result<query_param_view>
-    increment(
-        char const*& it,
-        char const* end
-            ) const noexcept;
-
-    result<query_param_view>
-    parse_query_param(
-        char const*& it,
-        char const* end
-            ) const noexcept;
 };
 
 constexpr query_rule_t query_rule{};


### PR DESCRIPTION
Instead of awkward function pointers we just store the begin and increment rules directly. Furthermore, if the small buffer size is insufficient, a dynamic allocation is performed. This allocation is based on the size of the rules, not the size of the range. None of the rules in the library currently exceed the small buffer size.