### PR TITLE
Adjust codecov threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,3 +23,9 @@ ignore:
   - extra/**/*
   - test/*
   - test/**/*
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
Let's test the codecov threshold setting. According to the documentation "this allows a x% drop from the previous base commit coverage".  