### PR TITLE
fix pip install in drone script

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -67,7 +67,7 @@ def main(ctx):
   ## Compiling as part of the boost superproject
   linux_cxx("CMake Superproject", "g++", packages="", buildscript="drone", buildtype="cmake-superproject", image="cppalliance/droneubuntu1804:1", globalenv=globalenv),
   ## Installing
-  # linux_cxx("CMake Install", "g++", packages="", buildscript="drone", buildtype="cmake1", image="cppalliance/droneubuntu1804:1", environment={'CMAKE_INSTALL_TEST': '1', 'DRONE_JOB_UUID': 'b6589fc6ab'}, globalenv=globalenv),
+  linux_cxx("CMake Install", "g++", packages="", buildscript="drone", buildtype="cmake1", image="cppalliance/droneubuntu1804:1", environment={'CMAKE_INSTALL_TEST': '1', 'DRONE_JOB_UUID': 'b6589fc6ab'}, globalenv=globalenv),
 
   # ------------------------------------------------------------------
 

--- a/.drone/drone.sh
+++ b/.drone/drone.sh
@@ -171,10 +171,8 @@ elif [ "$DRONE_JOB_BUILDTYPE" == "cmake1" ]; then
 
 echo '==================================> INSTALL'
 
-# https://bobbyhadz.com/blog/python-no-module-named-skbuild
-# https://github.com/scikit-build/cmake-python-distributions/issues/103
-pip install --user scikit-build
-
+# https://github.com/opencv/opencv-python#frequently-asked-questions
+pip install --upgrade pip
 pip install --user cmake
 
 echo '==================================> SCRIPT'

--- a/include/boost/url/url.hpp
+++ b/include/boost/url/url.hpp
@@ -150,7 +150,6 @@ public:
 
         @param u The url to construct from.
     */
-    BOOST_URL_DECL
     url(url_view_base const& u)
     {
         copy(u);

--- a/include/boost/url/url_view_base.hpp
+++ b/include/boost/url/url_view_base.hpp
@@ -76,10 +76,11 @@ class BOOST_SYMBOL_VISIBLE
 
     struct shared_impl;
 
+    BOOST_URL_DECL
     url_view_base() noexcept;
+    BOOST_URL_DECL
     explicit url_view_base(
         detail::url_impl const&) noexcept;
-
     ~url_view_base() = default;
     url_view_base(
         url_view_base const&) = default;

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -12,38 +12,20 @@ project(cmake_subdir_test LANGUAGES CXX)
 if(BOOST_CI_INSTALL_TEST)
     find_package(boost_url REQUIRED)
 else()
+    set(DEPENDENCIES
+        throw_exception core assert static_assert
+        config type_traits predef mp11 optional
+        winapi container_hash move intrusive
+        variant2 align system container io utility
+        detail preprocessor integer
+    )
+    foreach (dep ${DEPENDENCIES})
+        if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../../${dep}/CMakeLists.txt")
+            add_subdirectory(../../../${dep} boostorg/${dep})
+        endif()
+    endforeach()
+
     add_subdirectory(../.. boostorg/url)
-    add_subdirectory(../../../throw_exception boostorg/throw_exception)
-    add_subdirectory(../../../core boostorg/core)
-    add_subdirectory(../../../assert boostorg/assert)
-    add_subdirectory(../../../static_assert boostorg/static_assert)
-    add_subdirectory(../../../config boostorg/config)
-    add_subdirectory(../../../type_traits boostorg/type_traits)
-    add_subdirectory(../../../predef boostorg/predef)
-    add_subdirectory(../../../mp11 boostorg/mp11)
-    add_subdirectory(../../../optional boostorg/optional)
-    add_subdirectory(../../../winapi boostorg/winapi)
-    add_subdirectory(../../../container_hash boostorg/container_hash)
-    add_subdirectory(../../../move boostorg/move)
-    add_subdirectory(../../../intrusive boostorg/intrusive)
-    add_subdirectory(../../../variant2 boostorg/variant2)
-    add_subdirectory(../../../align boostorg/align)
-    add_subdirectory(../../../system boostorg/system)
-    add_subdirectory(../../../container boostorg/container)
-
-    add_subdirectory(../../../io boostorg/io)
-    add_subdirectory(../../../utility boostorg/utility)
-
-    # Conditional deps
-    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../../detail/CMakeLists.txt")
-        add_subdirectory(../../../detail boostorg/detail)
-    endif()
-    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../../preprocessor/CMakeLists.txt")
-        add_subdirectory(../../../preprocessor boostorg/preprocessor)
-    endif()
-    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../../../integer/CMakeLists.txt")
-        add_subdirectory(../../../integer boostorg/integer)
-    endif()
 endif()
 
 add_executable(main main.cpp)


### PR DESCRIPTION
With this PR, we fix all warnings we could have in CI. 

The only warning we are explicitly ignoring after that is `unused-function`. Since it's a problem with GCC6-8 that's already been fixed in GCC, there's nothing we can do about it. At most, we could include a link to the bug.

In the end, all we needed to fix the script was to upgrade pip. The cmake subdir test was also simplified to make errors there much less likely.