### PR TITLE
add examples to docs

### DIFF
--- a/doc/qbk/0.main.qbk
+++ b/doc/qbk/0.main.qbk
@@ -100,6 +100,8 @@
 
 [/-----------------------------------------------------------------------------]
 
+[import ../../example/magnet/magnet.cpp]
+[import ../../example/route/route.cpp]
 [import ../../test/unit/snippets.cpp]
 
 [/-----------------------------------------------------------------------------]
@@ -123,8 +125,8 @@
 [endsect]
 
 [include 6.0.grammar.qbk]
-
 [include 7.0.concepts.qbk]
+[include 8.0.examples.qbk]
 
 [section:ref Reference]
 [xinclude quickref.xml]

--- a/doc/qbk/8.0.examples.qbk
+++ b/doc/qbk/8.0.examples.qbk
@@ -1,0 +1,24 @@
+[/
+    Copyright (c) 2019 Vinnie Falco (vinnie.falco@gmail.com)
+
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+    Official repository: https://github.com/cppalliance/json
+]
+
+[/-----------------------------------------------------------------------------]
+
+[section Examples]
+[block'''<?dbhtml stop-chunking?>''']
+
+[section Magnet Link]
+[example_magnet]
+[endsect]
+
+[section Route]
+[example_route]
+[endsect]
+
+[endsect]
+

--- a/example/Jamfile
+++ b/example/Jamfile
@@ -8,4 +8,4 @@
 #
 
 build-project magnet ;
-build-project const_string ;
+build-project route ;

--- a/example/magnet/magnet.cpp
+++ b/example/magnet/magnet.cpp
@@ -5,6 +5,15 @@
 // https://www.boost.org/LICENSE_1_0.txt
 //
 
+//[example_magnet
+
+/*
+    This example parses a magnet link into a new
+    view type and prints its components to
+    standard output.
+*/
+
+
 #include <boost/url/url_view.hpp>
 #include <boost/url/optional.hpp>
 #include <boost/url/rfc/absolute_uri_rule.hpp>
@@ -719,3 +728,5 @@ int main(int argc, char** argv)
 
     return EXIT_SUCCESS;
 }
+
+//]

--- a/example/route/route.cpp
+++ b/example/route/route.cpp
@@ -7,6 +7,17 @@
 // Official repository: https://github.com/CppAlliance/url
 //
 
+//[example_route
+
+/*
+    This example defines a route for a URL path.
+    If the specified route matches and the file
+    exists, the example prints its contents to
+    standard output.
+*/
+
+
+
 #include <boost/url/error.hpp>
 #include <boost/url/segments_encoded.hpp>
 #include <boost/url/segments_encoded_view.hpp>
@@ -191,3 +202,5 @@ main(int argc, char **argv)
         return EXIT_FAILURE;
     }
 }
+
+//]


### PR DESCRIPTION
fix #305

This PR adds the examples to docs with the same pattern as Boost.Json.